### PR TITLE
fix: correct source.template.json

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{TAG}",
-  "url": "https://github.com/{USER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
 }


### PR DESCRIPTION
`{USER}` in the `url` failed when attempting to publish to bcr. I copied the wrong variable from toolchains_llvm's template. This change corrects the variable to `{OWNER}`

https://github.com/reutermj/toolchains_cc/actions/runs/17843915974/job/50739402810