### PR TITLE
chore: settup commitlint

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'type-enum': [
+            2,
+            'always',
+            [
+                'chore',
+                'docs',
+                'feat',
+                'fix'
+            ]
+        ],
+        'body-max-line-length': [0]
+    }
+};

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ bazel export-ignore
 bazel.bat export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.commitlintrc.js export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,24 @@ jobs:
       - name: Run buildifier
         run: |
           ./bazel run :buildifier.check
+
+  commitlint:
+    runs-on: ubuntu-latest
+    name: Run commitlint
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+
+      - name: Install commitlint
+        run: npm install -g @commitlint/cli @commitlint/config-conventional
+
+      - name: Run commitlint
+        run: |
+          npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.sha }} --verbose


### PR DESCRIPTION
Will be using a simplified version of conventional commits to generate release notes. Essentially the rules are: docs, feat, and fix determine which section of the release notes the commit message goes in, and chore dont appear in the release notes. There's no deeper meaning to all this