### PR TITLE
chore: Add a job for branch protection

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -11,6 +11,7 @@ module.exports = {
                 'fix'
             ]
         ],
-        'body-max-line-length': [0]
+        'body-max-line-length': [0],
+        'subject-case': [0]
     }
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
         run: |
           ./bazel build --repo_env=toolchains_cc_libc_version=${{ matrix.libc_version }} //...
 
+  all-matrix-builds:
+    runs-on: ubuntu-latest
+    name: All matrix builds passed
+    needs: [build]
+    
+    steps:
+      - name: No-Op
+        run: /bin/true
+
   buildifier:
     runs-on: ubuntu-latest
     name: Run buildifier


### PR DESCRIPTION
I want to protect main contingent on all the matrix jobs passing. I dont want to have to manually add each one. This adds a single target that waits for them all and then completes. I can wait on that one