### PR TITLE
chore: Revert "testing ci fails"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         libc_version: [
-          "2.27", "2.28", "2.29", "2.30", "2.31", "2.32", "2.33", "2.34", 
+          "2.28", "2.29", "2.30", "2.31", "2.32", "2.33", "2.34", 
           "2.35", "2.36", "2.37", "2.38", "2.39", "2.40", "2.41", "2.42"
         ]
       fail-fast: false  # Continue running other matrix jobs even if one fails


### PR DESCRIPTION
This reverts commit 06a2c7f67fb757e13432e3b0d7b37da8d2d14c04.