### PR TITLE
chore: increase modularity of gcc packages

### DIFF
--- a/.github/workflows/gcc/Dockerfile
+++ b/.github/workflows/gcc/Dockerfile
@@ -46,8 +46,8 @@ COPY step-2_build_crosstool_ng $SCRIPTS_DIR/step-2_build_crosstool_ng
 RUN $SCRIPTS_DIR/step-2_build_crosstool_ng
 
 ARG GCC_VERSION=15
-ARG LIBC=musl
-ARG LIBC_VERSION=1.2.5
+ARG LIBC=gnu
+ARG LIBC_VERSION=2.34
 COPY step-3_configure_toolchain $SCRIPTS_DIR/step-3_configure_toolchain
 RUN $SCRIPTS_DIR/step-3_configure_toolchain
 

--- a/.github/workflows/gcc/step-5_package_toolchain
+++ b/.github/workflows/gcc/step-5_package_toolchain
@@ -3,14 +3,50 @@ set -euox pipefail
 
 pushd "${OUTPUT_DIR}"
 GCC_FULL_VERSION=$("bin/x86_64-linux-${LIBC}-gcc" --version | head -n1 | awk '{print $NF}')
-RELEASE_NAME="x86_64-linux-${LIBC}-${LIBC_VERSION}-gcc-${GCC_FULL_VERSION}-$(date +%Y%m%d)"
+DATETIME=$(date +%Y%m%d)
+RELEASE_NAME="x86_64-linux-x86_64-linux-${LIBC}-${LIBC_VERSION}-gcc-${GCC_FULL_VERSION}-${DATETIME}"
 echo $RELEASE_NAME > ${WORK_DIR}/release_name
 
+# =======================
+# || Package libstdc++ ||
+# =======================
+LIBSTDCXX_FILES=()
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/include/c++/)
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/lib64/libitm*)
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/lib64/libstdc++*)
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/lib64/libsupc++*)
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/sysroot/lib/libitm*)
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/sysroot/lib/libstdc++*)
+LIBSTDCXX_FILES+=(x86_64-linux-${LIBC}/sysroot/lib/libsupc++*)
+
+XZ_OPT=-e9 tar cJf "${ARTIFACT_DIR}/x86_64-linux-${LIBC}-${LIBC_VERSION}-libstdcxx-${GCC_FULL_VERSION}-${DATETIME}.tar.xz" \
+    "${LIBSTDCXX_FILES[@]}"
+
+rm -rf "${LIBSTDCXX_FILES[@]}"
+
+# =======================================
+# || Package gcc compiler runtime libs ||
+# =======================================
+LIBGCC_FILES=()
+LIBGCC_FILES+=(lib/gcc)
+LIBGCC_FILES+=(x86_64-linux-${LIBC}/lib64/libgcc*)
+LIBGCC_FILES+=(x86_64-linux-${LIBC}/lib64/libatomic*)
+LIBGCC_FILES+=(x86_64-linux-${LIBC}/sysroot/lib/libgcc*)
+LIBGCC_FILES+=(x86_64-linux-${LIBC}/sysroot/lib/libatomic*)
+
+XZ_OPT=-e9 tar cJf "${ARTIFACT_DIR}/x86_64-linux-${LIBC}-${LIBC_VERSION}-libgcc-${GCC_FULL_VERSION}-${DATETIME}.tar.xz" \
+    "${LIBGCC_FILES[@]}"
+
+rm -rf "${LIBGCC_FILES[@]}"
+
+# =================
+# || Package gcc ||
+# =================
 XZ_OPT=-e9 tar cJf "${ARTIFACT_DIR}/${RELEASE_NAME}.tar.xz" \
     bin/ \
     lib/ \
     libexec/ \
     share/ \
-    "x86_64-linux-${LIBC}" \
+    "x86_64-linux-${LIBC}"
 
 popd


### PR DESCRIPTION
this gives the ability to use libstdc++ and gcc compiler runtime libs with clang without also downloading the gcc toolchain binaries.