### PR TITLE
chore: build ncurses

### DIFF
--- a/.github/workflows/gcc-standalone/Dockerfile
+++ b/.github/workflows/gcc-standalone/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest
+
+# =================
+# || Create User ||
+# =================
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y sudo gh
+
+RUN useradd -m -s /bin/bash builder && \
+    usermod -aG sudo builder
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER builder
+WORKDIR /home/builder
+
+# =======================
+# || Environment Setup ||
+# =======================
+ENV SCRIPTS_DIR="/tmp/scripts"
+
+# =====================
+# || Build Toolchain ||
+# =====================
+COPY step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
+RUN $SCRIPTS_DIR/step-1_install_dependencies
+
+COPY environment $SCRIPTS_DIR/environment
+
+COPY step-2_download_tarballs $SCRIPTS_DIR/step-2_download_tarballs
+RUN $SCRIPTS_DIR/step-2_download_tarballs
+
+COPY step-3_build_ncurses $SCRIPTS_DIR/step-3_build_ncurses
+RUN $SCRIPTS_DIR/step-3_build_ncurses

--- a/.github/workflows/gcc-standalone/environment
+++ b/.github/workflows/gcc-standalone/environment
@@ -3,7 +3,7 @@ set -euox pipefail
 
 export BUILD_TOOLS="/tmp/buildtools"
 export TARBALLS="/tmp/tarballs"
-mkdir ${TARBALLS}
+mkdir "${TARBALLS}"
 
 export NCURSES_TARBALL="${TARBALLS}/ncurses.tar.gz"
 

--- a/.github/workflows/gcc-standalone/environment
+++ b/.github/workflows/gcc-standalone/environment
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euox pipefail
+
+export BUILD_TOOLS="/tmp/buildtools"
+export TARBALLS="/tmp/tarballs"
+mkdir ${TARBALLS}
+
+export NCURSES_TARBALL="${TARBALLS}/ncurses.tar.gz"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "${GITHUB_ENV}"
+fi

--- a/.github/workflows/gcc-standalone/step-1_install_dependencies
+++ b/.github/workflows/gcc-standalone/step-1_install_dependencies
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euox pipefail
+
+sudo apt update
+DEBIAN_FRONTEND=noninteractive sudo apt install -y \
+    build-essential \
+    autoconf \
+    flex \
+    bison \
+    texinfo \
+    help2man \
+    file \
+    gawk \
+    libtool \
+    libtool-bin \
+    libncurses-dev \
+    python3 \
+    python3-dev \
+    unzip \
+    git \
+    wget \
+    curl

--- a/.github/workflows/gcc-standalone/step-2_download_tarballs
+++ b/.github/workflows/gcc-standalone/step-2_download_tarballs
@@ -12,4 +12,3 @@ if ! wget -O "${NCURSES_TARBALL}" "${NCURSES_URL}"; then
     wget -O "${NCURSES_TARBALL}" "${NCURSES_MIRROR}"
 fi
 
-popd

--- a/.github/workflows/gcc-standalone/step-2_download_tarballs
+++ b/.github/workflows/gcc-standalone/step-2_download_tarballs
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+# =============
+# || ncurses ||
+# =============
+NCURSES_VERSION="6.5"
+NCURSES_URL="https://invisible-mirror.net/archives/ncurses/ncurses-${NCURSES_VERSION}.tar.gz"
+NCURSES_MIRROR="https://ftp.gnu.org/gnu/ncurses/ncurses-${NCURSES_VERSION}.tar.gz"
+if ! wget -O "${NCURSES_TARBALL}" "${NCURSES_URL}"; then
+    wget -O "${NCURSES_TARBALL}" "${NCURSES_MIRROR}"
+fi
+
+popd

--- a/.github/workflows/gcc-standalone/step-3_build_ncurses
+++ b/.github/workflows/gcc-standalone/step-3_build_ncurses
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+# [DEBUG]    ==> Executing:  CFLAGS='-O2 -g -I/tmp/work/.build/x86_64-linux-gnu/buildtools/include   -std=gnu17' LDFLAGS='-L/tmp/work/.build/x86_64-linux-gnu/buildtools/lib  ' '/usr/bin/bash' '/tmp/work/.build/x86_64-linux-gnu/src/ncurses/configure' '--build=x86_64-build_pc-linux-gnu' '--host=x86_64-build_pc-linux-gnu' '--prefix=' '--with-install-prefix=/tmp/work/.build/x86_64-linux-gnu/buildtools' '--without-debug' '--enable-termcap' '--enable-symlinks' '--without-manpages' '--without-tests' '--without-cxx' '--without-cxx-binding' '--without-ada' '--without-fallbacks' '--disable-widec'
+# CFLAGS='-O2 -g -I/tmp/work/.build/x86_64-linux-gnu/buildtools/include   -std=gnu17' 
+# LDFLAGS='-L/tmp/work/.build/x86_64-linux-gnu/buildtools/lib  ' 
+# '/usr/bin/bash' '/tmp/work/.build/x86_64-linux-gnu/src/ncurses/configure' 
+# '--build=x86_64-build_pc-linux-gnu'
+# '--host=x86_64-build_pc-linux-gnu' 
+# '--prefix=' 
+# '--with-install-prefix=/tmp/work/.build/x86_64-linux-gnu/buildtools'
+# '--without-debug' 
+# '--enable-termcap' 
+# '--enable-symlinks' 
+# '--without-manpages' 
+# '--without-tests' 
+# '--without-cxx' 
+# '--without-cxx-binding' 
+# '--without-ada' 
+# '--without-fallbacks' 
+# '--disable-widec'
+
+
+NCURSES_DIR="/tmp/ncurses"
+mkdir -p ${NCURSES_DIR}
+
+tar -xzf "${NCURSES_TARBALL}" -C "${NCURSES_DIR}" --strip-components=1
+
+pushd "${NCURSES_DIR}"
+
+env CFLAGS='-O2 -g -I/tmp/work/.build/x86_64-linux-gnu/buildtools/include -std=gnu17' \
+    LDFLAGS='-L/tmp/work/.build/x86_64-linux-gnu/buildtools/lib ' \
+    ./configure \
+        --build=x86_64-build_pc-linux-gnu \
+        --host=x86_64-build_pc-linux-gnu \
+        --prefix= \
+        --with-install-prefix="${BUILD_TOOLS}" \
+        --without-debug \
+        --enable-termcap \
+        --enable-symlinks \
+        --without-manpages \
+        --without-tests \
+        --without-cxx \
+        --without-cxx-binding \
+        --without-ada \
+        --without-fallbacks \
+        --disable-widec
+
+make -j$(nproc)
+make install
+
+popd


### PR DESCRIPTION
crosstool-ng is great, but it's making it difficult to package things. break out of using crosstool-ng to make packaging easier