### PR TITLE
chore: clean up GCC build scripts and documentation

### DIFF
--- a/.github/workflows/gcc-standalone/step-14_build_glibc
+++ b/.github/workflows/gcc-standalone/step-14_build_glibc
@@ -30,8 +30,6 @@ env BUILD_CC=x86_64-linux-gnu-gcc \
         --enable-add-ons=no \
         --disable-werror
 
-# --cache-file=/tmp/work/.build/x86_64-linux-gnu/build/build-libc/multilib/config.cache \
-
 make -j$(nproc) -l \
     CXX="" \
     LDFLAGS="" \
@@ -49,13 +47,6 @@ make -j$(nproc) -l \
     BUILD_LDFLAGS="-L${BUILD_TOOLS}/lib" \
     install_root="${SYSROOT_DIR}" \
     install
-
-# ln -sfv x86_64-linux-gnu-gcc ${BUILD_TOOLS}/bin/x86_64-linux-gnu-cc
-# rm -rf sysroot-check
-# mkdir -p sysroot-check
-# touch sysroot-check/seen sysroot-check/unique
-# ln -sfv lib ${SYSROOT_DIR}/lib64
-# ln -sfv lib ${SYSROOT_DIR}/usr/lib64
 
 popd
 

--- a/.github/workflows/gcc-standalone/step-15_build_gcc
+++ b/.github/workflows/gcc-standalone/step-15_build_gcc
@@ -45,7 +45,9 @@ env CC_FOR_BUILD="x86_64-build_pc-linux-gnu-gcc" \
         --enable-long-long
 
 make -j$(nproc) -l all
-make install prefix="${OUTPUT_DIR}" exec_prefix="${OUTPUT_DIR}"
 make install prefix="${GCC_ARTIFACTS}" exec_prefix="${GCC_ARTIFACTS}"
+
+MESSAGE="See https://github.com/reutermj/toolchains_cc/blob/main/lore/gcc/load_bearing_directories.md"
+echo ${MESSAGE} > ${GCC_ARTIFACTS}/lib/keep_load_bearing_directory
 
 popd

--- a/.github/workflows/gcc-standalone/step-17_upload_release
+++ b/.github/workflows/gcc-standalone/step-17_upload_release
@@ -6,7 +6,7 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     exit 0
 fi
 
-GCC_FULL_VERSION=$("${OUTPUT_DIR}/bin/x86_64-linux-gnu-gcc" --version | head -n1 | awk '{print $NF}')
+GCC_FULL_VERSION=$("${GCC_ARTIFACTS}/bin/x86_64-linux-gnu-gcc" --version | head -n1 | awk '{print $NF}')
 RELEASE_NAME=$(cat ${WORK_DIR}/release_name)
 
 gh release create "${RELEASE_NAME}" \


### PR DESCRIPTION
## Summary

- Removed commented-out code and obsolete workarounds from GCC build scripts
- Fixed variable reference in upload script (OUTPUT_DIR → GCC_ARTIFACTS)
- Added placeholder file creation in lib/ directory to preserve load-bearing directory structure
- Streamlined load_bearing_directories.md documentation by removing verbose sections and converting headings to question form

## Test plan

- [x] Verify CI passes for all configurations
- [x] Verify buildifier checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)