### PR TITLE
fix: add missing package step to gcc standalone workflow

### DIFF
--- a/.github/workflows/build_gcc_standalone.yml
+++ b/.github/workflows/build_gcc_standalone.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build GCC
         run: $SCRIPTS_DIR/step-15_build_gcc
 
+      - name: Package Toolchain
+        run: $SCRIPTS_DIR/step-16_package_toolchain
+
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v3.0.0
         with:
@@ -75,4 +78,4 @@ jobs:
       - name: Upload Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: $SCRIPTS_DIR/step-6_upload_release
+        run: $SCRIPTS_DIR/step-17_upload_release


### PR DESCRIPTION
## Summary
Fixes the `build_gcc_standalone.yml` workflow that was failing with "Could not find subject at path /tmp/artifacts/*.tar.xz" by adding the missing package step and correcting the upload script reference.

## Problem
The attestation step expected `.tar.xz` files in `/tmp/artifacts/` but they didn't exist because the workflow was missing the packaging step.

## Changes
- Added "Package Toolchain" step (step-16) between building GCC and attestation
- Fixed upload release step to reference correct script (`step-17_upload_release` instead of `step-6_upload_release`)

## Testing
The workflow now matches the Dockerfile's complete build sequence (steps 1-17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)