### PR TITLE
docs: restructure runbook references for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **BEFORE ANYTHING ELSE**: Run `bd onboard` and follow the instructions to set up the beads development environment.
 
-## Documentation Structure
+## Runbooks
 
-This CLAUDE.md file contains frequently-used context and quick references. For detailed procedures and runbooks that are used less frequently, see [docs/runbooks/](docs/runbooks/). This structure minimizes token usage while keeping important information accessible.
+This CLAUDE.md file contains frequently-used context and quick references. Detailed procedures are in [docs/runbooks/](docs/runbooks/). **When a runbook's context occurs, ALWAYS read the runbook BEFORE taking any action.**
 
-## Development Guidelines
-
-**Commit messages**: Follow the structured format in [docs/runbooks/commit-message-guidelines.md](docs/runbooks/commit-message-guidelines.md). Use markdown with required sections: Problem (why?), Context (what's wrong?), Solution (what approach?), Rationale (why this way?).
+- **Before creating any commit**: Read [docs/runbooks/commit-message-guidelines.md](docs/runbooks/commit-message-guidelines.md)
+- **Before adding new toolchain configurations**: Read [docs/runbooks/add-toolchain-configuration.md](docs/runbooks/add-toolchain-configuration.md)
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary
Restructures CLAUDE.md to make runbook references more explicit and action-oriented, ensuring Claude consistently reads runbooks before taking actions.

## Problem
Claude wasn't consistently reading runbooks before taking actions (e.g., creating commits without first reading commit-message-guidelines.md).

## Changes
- Consolidated "Documentation Structure" and "Development Guidelines" sections into a single "Runbooks" section
- Added explicit mandate: "When a runbook's context occurs, ALWAYS read the runbook BEFORE taking any action"
- Reformatted runbook references as trigger-action pairs: "Before [action]: Read [runbook]"
- Included both commit guidelines and toolchain configuration runbooks as examples

## Rationale
The trigger-first format ("Before creating any commit") makes it immediately clear when a runbook should be consulted. The consolidated structure prevents runbooks from being scattered and overlooked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)