### PR TITLE
feat: add --update-bazelisk flag to bazel wrapper script

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Determine OS type
 OS="$(uname -s)"
@@ -33,6 +33,36 @@ esac
 # Construct the path to the Bazelisk binary
 DIRNAME=$(dirname $(readlink -f "$0"))
 BAZELISK_BINARY="${DIRNAME}/bazelisk-${OS}-${ARCH}"
+
+# Check for --update-bazelisk flag
+if [ "$1" = "--update-bazelisk" ]; then
+    echo "Updating bazelisk binaries..."
+
+    CURRENT_VERSION=$("$BAZELISK_BINARY" version | head -n1 | sed 's/Bazelisk version: //')
+    echo "Current version: $CURRENT_VERSION"
+
+    LATEST_VERSION=$(gh release view --repo bazelbuild/bazelisk --json tagName -q .tagName)
+    echo "Latest version: $LATEST_VERSION"
+
+    if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+        echo "Already at latest version!"
+        exit 0
+    fi
+
+    rm -f "${DIRNAME}"/bazelisk-*
+
+    gh release download "$LATEST_VERSION" \
+        --repo bazelbuild/bazelisk \
+        --pattern "bazelisk-linux-*" \
+        --pattern "bazelisk-darwin-*" \
+        --pattern "bazelisk-windows-*" \
+        --dir "$DIRNAME"
+
+    chmod +x "${DIRNAME}"/bazelisk-linux-* "${DIRNAME}"/bazelisk-darwin-*
+
+    echo "Successfully updated to $LATEST_VERSION"
+    exit 0
+fi
 
 # Check if the binary exists
 if [ ! -x "$BAZELISK_BINARY" ]; then


### PR DESCRIPTION
## Summary

Adds a `--update-bazelisk` flag to the `tools/bazel` wrapper script that automatically updates all bazelisk binaries to the latest release.

## Changes

- Added `--update-bazelisk` flag handling to `tools/bazel`
- Automatically detects current and latest bazelisk versions
- Downloads all platform binaries (linux, darwin, windows for amd64/arm64) using `gh` CLI
- Sets appropriate executable permissions on Unix binaries
- Enables bash strict mode (`-e`) for better error handling

## Usage

```bash
./tools/bazel --update-bazelisk
```

The script will:
1. Check current bazelisk version
2. Query GitHub for the latest release
3. Skip update if already on latest version
4. Download all platform binaries if update is needed
5. Set executable permissions
6. Report success

## Test Plan

- [x] Verify version check works correctly
- [x] Confirm all platform binaries are downloaded
- [x] Ensure executable permissions are set correctly on Unix binaries
- [x] Test that script skips update when already on latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)