### PR TITLE
fix: correct WORK_DIR references in release upload script

### DIFF
--- a/.github/workflows/gcc-standalone/step-17_upload_release
+++ b/.github/workflows/gcc-standalone/step-17_upload_release
@@ -7,11 +7,10 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
 fi
 
 GCC_FULL_VERSION=$("${GCC_ARTIFACTS}/bin/x86_64-linux-gnu-gcc" --version | head -n1 | awk '{print $NF}')
-RELEASE_NAME=$(cat ${WORK_DIR}/release_name)
+RELEASE_NAME=$(cat ${GCC_ARTIFACTS}/release_name)
 
 gh release create "${RELEASE_NAME}" \
     ${ARTIFACTS_DIR}/*.tar.xz \
-    ${WORK_DIR}/build.log \
     --repo=https://github.com/reutermj/toolchains_cc \
     --latest=false \
     --title="${RELEASE_NAME}" \


### PR DESCRIPTION
## Summary

Fixes the GCC standalone build workflow failure during release upload by correcting undefined variable references.

**Changes**:
- Replace `${WORK_DIR}/release_name` with `${GCC_ARTIFACTS}/release_name` 
- Remove non-existent `${WORK_DIR}/build.log` from release upload

**Root cause**: The `WORK_DIR` variable was never defined in the environment script, and `build.log` is not created by any build step.

## Test Plan

- [ ] Workflow builds successfully 
- [ ] Release upload step completes without "unbound variable" error
- [ ] GitHub release is created with tarball artifacts
- [ ] Release name is correctly read from `${GCC_ARTIFACTS}/release_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)