### PR TITLE
feat: migrate Bazel extension settings to project-level configuration

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euox pipefail
 
-mkdir -p .vscode
-cp .devcontainer/settings.json .vscode/
-
 # Install Claude Code
 curl -fsSL https://claude.ai/install.sh | bash
 

--- a/.devcontainer/settings.json
+++ b/.devcontainer/settings.json
@@ -1,5 +1,0 @@
-{
-    "claudeCode.allowDangerouslySkipPermissions": true,
-    "claudeCode.initialPermissionMode": "bypassPermissions",
-    "bazel.buildifierExecutable": "./bazel run -- @buildifier_prebuilt//:buildifier"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 bazel-*
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "bazel.buildifierExecutable": "./bazel run -- @buildifier_prebuilt//:buildifier",
+    "bazel.executable": "./bazel"
+}


### PR DESCRIPTION
## Summary

- Moved Bazel VSCode extension configuration to tracked `.vscode/settings.json`
- Removed `.vscode` from `.gitignore` to enable project-level settings tracking
- Deleted `.devcontainer/settings.json` (Claude settings can be configured at user level)
- Removed hacky copy logic from `post-create.sh`

## Test Plan

- [ ] Rebuild devcontainer and verify Bazel extension uses correct executable paths
- [ ] Verify `./bazel` wrapper is used by VSCode Bazel extension
- [ ] Verify buildifier integration works with `./bazel run -- @buildifier_prebuilt//:buildifier`
- [ ] Confirm Claude Code settings can be configured at user level without project files

🤖 Generated with [Claude Code](https://claude.com/claude-code)