### PR TITLE
docs: add comment philosophy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Runbooks
 
-Runbooks are detaild procedures for use in a specific context. 
+Runbooks are detaild procedures for use in a specific context.
 **When a runbook's context occurs, YOU MUST ALWAYS read the runbook BEFORE taking any action.**
 
 - **BEFORE creating any commit, YOU MUST read**: [docs/runbooks/commit-message-guidelines.md](docs/runbooks/commit-message-guidelines.md)
@@ -46,6 +46,89 @@ Use the `./bazel` wrapper script instead of `bazel`
 # Auto-fix Bazel file formatting
 ./bazel run :buildifier.fix
 ```
+
+## Comment Philosophy
+
+**ALWAYS follow these guidelines when writing or modifying code comments.**
+
+### Core Principles
+
+1. **Inline comments answer "why?"** - Why this choice? Why this workaround? Why this optimization?
+2. **Doc comments answer "what?"** - What does this function/class do? What's the API?
+3. **Code answers "how?"** - Through clear naming, good factoring, and self-documenting structure
+4. **Commit messages provide rationale** - Longer explanations of design decisions
+5. **Links are valuable** - Point to issues, bug trackers, docs, RFCs, etc.
+6. **TODOs go in beads** - Not in source code comments
+
+### Good Reasons for Inline Comments
+
+- Workarounds for bugs in dependencies
+- Non-obvious constraints from external systems
+- Performance optimizations that might seem unusual
+- Design tradeoffs that aren't obvious from the code
+
+### Links and References
+
+**Link format:**
+- **Current repo GitHub issues:** Use short form `#1234`
+- **External issues/bugs:** Use full URL `https://github.com/org/repo/issues/1234`
+- **Current repo docs:** Use relative path from repo root `docs/architecture.md`
+- **External docs:** Use full URL `https://sourceware.org/glibc/wiki/ABICompatibility`
+- **Beads issues:** Use full ID `toolchains_cc-di2`
+
+**Combining references:** When helpful, include both a beads reference (for agent/internal tracking) and an external link (for human readers):
+
+```c++
+// Prevent RSS bloat in long-running processes (toolchains_cc-di2)
+// https://sourceware.org/bugzilla/show_bug.cgi?id=11261
+malloc_trim(0);
+```
+
+### Examples
+
+**Good - Dependency workaround:**
+```python
+# Bazel requires explicit include paths for cross-compilation
+# See: https://github.com/bazelbuild/bazel/issues/12345
+builtin_include_dirs = [...]
+```
+
+**Good - Platform-specific workaround:**
+```c++
+#ifdef __GLIBC__
+// Prevent RSS bloat in long-running processes (bd-456)
+// https://sourceware.org/bugzilla/show_bug.cgi?id=11261
+malloc_trim(0);
+#endif
+```
+
+**Good - Performance optimization:**
+```python
+# Cache lookups because toolchain resolution is expensive
+# (involves filesystem scanning and version parsing)
+if target_triple in _cache:
+    return _cache[target_triple]
+```
+
+**Bad - Explains "what?" (obvious):**
+```c++
+// Calculate the sum of two numbers
+int add(int a, int b) { return a + b; }
+```
+
+**Bad - TODO in code (use beads instead):**
+```c++
+// TODO: Add ARM64 support  ❌
+```
+
+### Before Adding "How?" Comments
+
+Try these alternatives first:
+1. Rename variables/functions to be more descriptive
+2. Extract complex expressions into named variables
+3. Break complex logic into smaller, well-named functions
+
+If code truly requires a "how?" explanation despite refactoring attempts, add the comment. Don't let the code remain obscure.
 
 ## Issue Tracking with bd (beads)
 


### PR DESCRIPTION
## Summary

- Adds standardized comment philosophy guidelines to CLAUDE.md
- Establishes when and how to write code comments effectively
- Defines link formatting conventions for issues, bugs, and documentation
- Clarifies that TODOs belong in beads issue tracking, not source code

## Changes

- Added "Comment Philosophy" section to CLAUDE.md with:
  - Core principles (why/what/how separation)
  - Good reasons for inline comments (workarounds, constraints, optimizations)
  - Link formatting conventions (repo issues, external bugs, beads references)
  - Concrete examples of good and bad commenting practices
  - Guidance on refactoring before adding "how?" comments
- Created beads issue toolchains_cc-di2 for future link checker in CI
- Minor whitespace cleanup

## Rationale

Without explicit guidelines, commenting practices can be inconsistent. This philosophy:
- Keeps comments focused on "why?" (design decisions not visible in code)
- Encourages self-documenting code over explanatory comments
- Provides structured references (beads + external URLs) for both agents and humans
- Moves future work tracking to beads where it can be prioritized and managed

## Test Plan

- [x] Guidelines added to CLAUDE.md and visible to AI agents
- [x] Examples demonstrate the philosophy clearly
- [x] Beads issue created and synced to git
- [x] Commit follows repository commit message guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)