### PR TITLE
feat: package glibc separately in build_gcc_standalone workflow

### DIFF
--- a/.github/workflows/build_gcc_standalone/environment
+++ b/.github/workflows/build_gcc_standalone/environment
@@ -27,6 +27,7 @@ export BINUTILS_SOURCE="/tmp/binutils-source"
 export EXPAT_SOURCE="/tmp/expat-source"
 export GCC_ARTIFACTS="/tmp/gcc-artifacts"
 export GCC_SOURCE="/tmp/gcc-source"
+export GLIBC_ARTIFACTS="/tmp/glibc-artifacts"
 export GLIBC_SOURCE="/tmp/glibc-source"
 export GMP_SOURCE="/tmp/gmp-source"
 export ISL_SOURCE="/tmp/isl-source"
@@ -42,6 +43,7 @@ mkdir -p ${BINUTILS_SOURCE}
 mkdir -p ${EXPAT_SOURCE}
 mkdir -p ${GCC_SOURCE}
 mkdir -p ${GCC_ARTIFACTS}
+mkdir -p ${GLIBC_ARTIFACTS}
 mkdir -p ${GLIBC_SOURCE}
 mkdir -p ${GMP_SOURCE}
 mkdir -p ${ISL_SOURCE}

--- a/.github/workflows/build_gcc_standalone/step-14_build_glibc
+++ b/.github/workflows/build_gcc_standalone/step-14_build_glibc
@@ -48,6 +48,15 @@ make -j$(nproc) -l \
     install_root="${SYSROOT_DIR}" \
     install
 
+make -j$(nproc) -l \
+    CXX="" \
+    default_cflags="" \
+    BUILD_CFLAGS="-O2 -g -I${BUILD_TOOLS}/include" \
+    BUILD_CPPFLAGS="" \
+    BUILD_LDFLAGS="-L${BUILD_TOOLS}/lib" \
+    install_root="${GLIBC_ARTIFACTS}" \
+    install
+
 popd
 
 # Why --disable-cet and -fcf-protection=none?

--- a/.github/workflows/build_gcc_standalone/step-16_package_toolchain
+++ b/.github/workflows/build_gcc_standalone/step-16_package_toolchain
@@ -41,6 +41,16 @@ XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/x86_64-linux-gnu-glibc-${GLIBC_VERSION}-lib
 
 rm -rf "${LIBGCC_FILES[@]}"
 
+# ==================
+# || Package glibc ||
+# ==================
+pushd "${GLIBC_ARTIFACTS}"
+
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/x86_64-linux-gnu-glibc-${GLIBC_VERSION}-${DATETIME}.tar.xz" \
+    usr/
+
+popd
+
 # =================
 # || Package gcc ||
 # =================


### PR DESCRIPTION
## Summary

Adds separate glibc packaging to the build_gcc_standalone workflow, creating a standalone glibc artifact alongside the existing GCC, libstdc++, and libgcc packages.

## Changes

- **environment**: Add GLIBC_ARTIFACTS directory for packaging
- **step-14_build_glibc**: Install glibc to both SYSROOT_DIR and GLIBC_ARTIFACTS
- **step-16_package_toolchain**: Package glibc as `x86_64-linux-gnu-glibc-VERSION-DATE.tar.xz`

## Test Results

Full Docker build completed successfully:
- ✅ GLIBC_ARTIFACTS directory created correctly
- ✅ Dual glibc installation works without errors
- ✅ All 4 packages generated:
  - `x86_64-linux-gnu-glibc-2.28-libstdcxx-15.2.0-20251124.tar.xz`
  - `x86_64-linux-gnu-glibc-2.28-libgcc-15.2.0-20251124.tar.xz`
  - `x86_64-linux-gnu-glibc-2.28-20251124.tar.xz` (new)
  - `x86_64-linux-x86_64-linux-gnu-glibc-2.28-gcc-15.2.0-20251124.tar.xz`

## Rationale

The existing workflow builds glibc but only installs it to the sysroot for GCC. This change enables distribution of glibc as a standalone artifact without modifying the existing GCC build process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)