### PR TITLE
fix: vendor GMP tarball in GitHub release

### DIFF
--- a/.github/workflows/build_gcc_standalone/step-02_download_source
+++ b/.github/workflows/build_gcc_standalone/step-02_download_source
@@ -41,10 +41,12 @@ git clone --depth 1 \
 # =========
 # || gmp ||
 # =========
-# TODO: gmp uses Mercurial instead of get. using wget for now
+# gmplib.org is unreliable when running on GitHub Actions runners.
+# Downloading from our vendored dependencies release instead.
+# See: https://github.com/reutermj/toolchains_cc/releases/tag/dependencies-v1
 GMP_TARBALL="${TARBALLS}/gmp.tar.xz"
 GMP_VERSION="6.3.0"
-GMP_URL="https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz"
+GMP_URL="https://github.com/reutermj/toolchains_cc/releases/download/dependencies-v1/gmp-${GMP_VERSION}.tar.xz"
 wget -O "${GMP_TARBALL}" "${GMP_URL}"
 tar xvf "${GMP_TARBALL}" -C "${GMP_SOURCE}" --strip-components=1
 


### PR DESCRIPTION
## Summary

- Vendors GMP 6.3.0 tarball in a GitHub release (dependencies-v1) to avoid unreliable downloads from gmplib.org
- Updates build script to fetch from our GitHub release instead of upstream

## Problem

The gmplib.org download fails frequently on GitHub Actions runners, causing intermittent CI build failures with connection timeouts.

## Solution

- Created [dependencies-v1](https://github.com/reutermj/toolchains_cc/releases/tag/dependencies-v1) release with gmp-6.3.0.tar.xz
- Updated [step-02_download_source](.github/workflows/build_gcc_standalone/step-02_download_source) to download from GitHub release
- Added comment explaining the rationale

## Test Plan

- [ ] Verify CI build downloads GMP successfully from GitHub release
- [ ] Confirm build completes without download failures
- [ ] Validate that the GMP tarball from our release is identical to upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)