### PR TITLE
feat: add build_glibc workflow for standalone glibc builds

### DIFF
--- a/.github/workflows/build_glibc.yml
+++ b/.github/workflows/build_glibc.yml
@@ -1,0 +1,55 @@
+name: Build glibc
+
+on:
+  workflow_dispatch:
+    inputs:
+      glibc_version:
+        description: 'glibc version to build (e.g., 2.28, 2.39)'
+        required: true
+        type: string
+      target:
+        description: 'Target triple (e.g., x86_64-linux-gnu)'
+        required: false
+        type: string
+        default: 'x86_64-linux-gnu'
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_glibc
+  GLIBC_VERSION: ${{ inputs.glibc_version }}
+  TARGET: ${{ inputs.target }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.0
+
+      - name: Install dependencies
+        run: ${{ env.SCRIPTS_DIR }}/step-1_install_dependencies
+
+      - name: Set up environment
+        run: ${{ env.SCRIPTS_DIR }}/environment
+
+      - name: Download glibc source
+        run: ${{ env.SCRIPTS_DIR }}/step-2_download_glibc_source
+
+      - name: Download Linux kernel headers source
+        run: ${{ env.SCRIPTS_DIR }}/step-3_download_linux_source
+
+      - name: Install Linux kernel headers
+        run: ${{ env.SCRIPTS_DIR }}/step-4_install_linux_headers
+
+      - name: Build glibc
+        run: ${{ env.SCRIPTS_DIR }}/step-5_build_glibc
+
+      - name: Package glibc
+        run: ${{ env.SCRIPTS_DIR }}/step-6_package_glibc
+
+      - name: Upload to GitHub Releases
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ${{ env.SCRIPTS_DIR }}/step-7_upload_release

--- a/.github/workflows/build_glibc/Dockerfile
+++ b/.github/workflows/build_glibc/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:latest
+
+# Build arguments for parameterizing glibc version and target
+ARG GLIBC_VERSION=2.28
+ARG TARGET=x86_64-linux-gnu
+
+# =================
+# || Create User ||
+# =================
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y sudo
+
+RUN useradd -m -s /bin/bash builder && \
+    usermod -aG sudo builder
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER builder
+WORKDIR /home/builder
+
+# =================
+# || Environment ||
+# =================
+ENV SCRIPTS_DIR="/tmp/scripts"
+COPY environment $SCRIPTS_DIR/environment
+
+ENV GLIBC_VERSION=${GLIBC_VERSION}
+ENV TARGET=${TARGET}
+
+# =====================
+# || Build glibc     ||
+# =====================
+COPY step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
+RUN $SCRIPTS_DIR/step-1_install_dependencies
+
+COPY step-2_download_glibc_source $SCRIPTS_DIR/step-2_download_glibc_source
+RUN $SCRIPTS_DIR/step-2_download_glibc_source
+
+COPY step-3_download_linux_source $SCRIPTS_DIR/step-3_download_linux_source
+RUN $SCRIPTS_DIR/step-3_download_linux_source
+
+COPY step-4_install_linux_headers $SCRIPTS_DIR/step-4_install_linux_headers
+RUN $SCRIPTS_DIR/step-4_install_linux_headers
+
+COPY step-5_build_glibc $SCRIPTS_DIR/step-5_build_glibc
+RUN $SCRIPTS_DIR/step-5_build_glibc
+
+COPY step-6_package_glibc $SCRIPTS_DIR/step-6_package_glibc
+RUN $SCRIPTS_DIR/step-6_package_glibc
+
+# The artifact will be in /tmp/artifacts/
+# You can extract it with: docker cp <container>:/tmp/artifacts/ .

--- a/.github/workflows/build_glibc/environment
+++ b/.github/workflows/build_glibc/environment
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euox pipefail
+
+# Build parameters from workflow
+export GLIBC_VERSION="${GLIBC_VERSION}"
+export TARGET="${TARGET:-x86_64-linux-gnu}"
+
+# Directory structure
+export OUTPUT_DIR="/tmp/output"
+export SYSROOT_DIR="${OUTPUT_DIR}/${TARGET}/sysroot"
+export ARTIFACTS_DIR="/tmp/artifacts"
+
+# Source directories
+export GLIBC_SOURCE="/tmp/glibc-source"
+export LINUX_SOURCE="/tmp/linux-source"
+export GLIBC_ARTIFACTS="/tmp/glibc-artifacts"
+
+# Create directory structure
+mkdir -p "${OUTPUT_DIR}"
+mkdir -p "${SYSROOT_DIR}"
+mkdir -p "${SYSROOT_DIR}/usr/include"
+mkdir -p "${SYSROOT_DIR}/lib"
+mkdir -p "${SYSROOT_DIR}/usr/lib"
+mkdir -p "${ARTIFACTS_DIR}"
+mkdir -p "${GLIBC_SOURCE}"
+mkdir -p "${LINUX_SOURCE}"
+mkdir -p "${GLIBC_ARTIFACTS}"
+
+# Export to GitHub Actions environment if running in CI
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "${GITHUB_ENV}"
+fi

--- a/.github/workflows/build_glibc/step-1_install_dependencies
+++ b/.github/workflows/build_glibc/step-1_install_dependencies
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euox pipefail
+
+sudo apt update
+DEBIAN_FRONTEND=noninteractive sudo apt install -y \
+    build-essential \
+    bison \
+    gawk \
+    python3 \
+    wget \
+    git \
+    rsync

--- a/.github/workflows/build_glibc/step-2_download_glibc_source
+++ b/.github/workflows/build_glibc/step-2_download_glibc_source
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+git clone --depth 1 \
+    --branch "glibc-${GLIBC_VERSION}" \
+    https://sourceware.org/git/glibc.git "${GLIBC_SOURCE}"

--- a/.github/workflows/build_glibc/step-3_download_linux_source
+++ b/.github/workflows/build_glibc/step-3_download_linux_source
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+# Download Linux kernel headers
+# Using 6.12 as a stable recent version
+LINUX_VERSION="6.12"
+git clone --depth 1 \
+    --branch "v${LINUX_VERSION}" \
+    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git "${LINUX_SOURCE}"

--- a/.github/workflows/build_glibc/step-4_install_linux_headers
+++ b/.github/workflows/build_glibc/step-4_install_linux_headers
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+LINUX_BUILD_DIR="/tmp/build-kernel-headers"
+mkdir -p "${LINUX_BUILD_DIR}"
+
+pushd "${LINUX_SOURCE}"
+
+make \
+    "HOSTCC=gcc" \
+    "O=${LINUX_BUILD_DIR}" \
+    "ARCH=x86" \
+    "INSTALL_HDR_PATH=${SYSROOT_DIR}/usr" \
+    "V=0" \
+    headers_install
+
+popd

--- a/.github/workflows/build_glibc/step-5_build_glibc
+++ b/.github/workflows/build_glibc/step-5_build_glibc
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+GLIBC_BUILD_DIR="/tmp/glibc-build"
+mkdir -p "${GLIBC_BUILD_DIR}"
+
+pushd "${GLIBC_BUILD_DIR}"
+
+# Build glibc using host GCC
+# Unlike the bootstrap approach, we use the system GCC directly
+env BUILD_CC=gcc \
+    CC="gcc -g -O2 -fcommon -U_FORTIFY_SOURCE -Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-implicit-int -fcf-protection=none" \
+    CFLAGS="-fcf-protection=none" \
+    AR=ar \
+    RANLIB=ranlib \
+    ${GLIBC_SOURCE}/configure \
+        --prefix=/usr \
+        --host=${TARGET} \
+        --without-cvs \
+        --disable-profile \
+        --without-gd \
+        --with-headers=${SYSROOT_DIR}/usr/include \
+        --disable-debug \
+        --disable-cet \
+        --disable-sanity-checks \
+        --enable-obsolete-rpc \
+        --enable-kernel="" \
+        --with-__thread \
+        --with-tls \
+        --enable-shared \
+        --enable-add-ons=no \
+        --disable-werror
+
+make -j$(nproc) -l \
+    CXX="" \
+    LDFLAGS="" \
+    default_cflags="" \
+    BUILD_CFLAGS="-O2 -g" \
+    BUILD_CPPFLAGS="" \
+    BUILD_LDFLAGS="" \
+    all
+
+# Install to GLIBC_ARTIFACTS for packaging
+make -j$(nproc) -l \
+    CXX="" \
+    default_cflags="" \
+    BUILD_CFLAGS="-O2 -g" \
+    BUILD_CPPFLAGS="" \
+    BUILD_LDFLAGS="" \
+    install_root="${GLIBC_ARTIFACTS}" \
+    install
+
+popd
+
+# Disable CET (Control-flow Enforcement Technology) to avoid linker errors
+# with older glibc versions that don't fully support it.
+# See build_gcc_standalone/step-14_build_glibc for details on the specific error.

--- a/.github/workflows/build_glibc/step-6_package_glibc
+++ b/.github/workflows/build_glibc/step-6_package_glibc
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${GLIBC_ARTIFACTS}"
+
+# Package format: <target>-glibc-<version>-<datetime>.tar.xz
+# Example: x86_64-linux-gnu-glibc-2.28-20241130.tar.xz
+DATETIME=$(date +%Y%m%d)
+PACKAGE_NAME="${TARGET}-glibc-${GLIBC_VERSION}-${DATETIME}.tar.xz"
+RELEASE_NAME="glibc-${GLIBC_VERSION}-${DATETIME}"
+
+# Save release name for upload step
+echo "${RELEASE_NAME}" > "${ARTIFACTS_DIR}/release_name"
+
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" usr/
+
+popd

--- a/.github/workflows/build_glibc/step-7_upload_release
+++ b/.github/workflows/build_glibc/step-7_upload_release
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "GITHUB_TOKEN is not set, exiting"
+    exit 0
+fi
+
+# Release name format: glibc-<version>-<datetime>
+# Example: glibc-2.28-20241130
+RELEASE_NAME=$(cat "${ARTIFACTS_DIR}/release_name")
+
+echo "Creating release ${RELEASE_NAME}"
+gh release create "${RELEASE_NAME}" \
+    ${ARTIFACTS_DIR}/*.tar.xz \
+    --title "${RELEASE_NAME}" \
+    --notes "glibc ${GLIBC_VERSION} build for ${TARGET}"
+
+echo "Successfully created release ${RELEASE_NAME}"


### PR DESCRIPTION
Problem
================================================================================

Building glibc as part of the GCC toolchain workflow requires rebuilding glibc for every GCC version, creating unnecessary build overhead and complexity in the Bazel packaging code.

Context
================================================================================

Currently, glibc is built within the build_gcc_standalone workflow, which means each GCC version build includes its own glibc build. This requires packaging glibc multiple times (once per GCC version) and complicates the Bazel configuration.

What functionality is missing?
--------------------------------------------------------------------------------

- No way to build glibc independently of GCC
- Can't reuse a single glibc build across multiple GCC versions
- Bazel code must handle GCC-glibc version pairs instead of treating them independently

What user experience is blocked?
--------------------------------------------------------------------------------

- Lengthy build times due to rebuilding glibc unnecessarily for each GCC version
- Complex Bazel configuration with GCC-glibc version matrices

Solution
================================================================================

Create a new build_glibc workflow that builds glibc independently using the host GCC compiler. The workflow:

- Uses host GCC instead of a bootstrap compiler
- Produces standalone glibc packages (x86_64-linux-gnu-glibc-2.28-20241130.tar.xz)
- Creates timestamped releases (glibc-2.28-20241130)
- Includes Dockerfile for local testing
- Can be triggered manually with configurable glibc version and target

Rationale
================================================================================

Why use host GCC instead of bootstrap compiler?
--------------------------------------------------------------------------------

Simpler and faster: eliminates the multi-stage bootstrap process. Since glibc is only used at build-time for linking (not deployed to runtime systems), the GCC version used to build it doesn't affect the symbols or ABI that applications link against.

Why create a standalone workflow?
--------------------------------------------------------------------------------

Decouples glibc builds from GCC builds, enabling reuse of one glibc build (e.g., 2.28) with multiple GCC versions (14.x, 15.x). This reduces the total number of builds needed for the full support matrix and simplifies the Bazel packaging process.

Why include datetime in release names?
--------------------------------------------------------------------------------

Allows rebuilding the same glibc version over time with fixes or configuration changes while maintaining previous versions for toolchains_cc functionality. Matches the pattern established by the build_gcc_standalone workflow.

Why not package from existing GCC builds?
--------------------------------------------------------------------------------

Considered extracting glibc from existing GCC toolchain builds, but wanted more control over the build process and versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)