### PR TITLE
fix: prevent glibc artifact releases from showing as latest

### DIFF
--- a/.github/workflows/build_glibc/step-7_upload_release
+++ b/.github/workflows/build_glibc/step-7_upload_release
@@ -15,6 +15,7 @@ echo "Creating release ${RELEASE_NAME}"
 gh release create "${RELEASE_NAME}" \
     ${ARTIFACTS_DIR}/*.tar.xz \
     --title "${RELEASE_NAME}" \
-    --notes "glibc ${GLIBC_VERSION} build for ${TARGET}"
+    --notes "glibc ${GLIBC_VERSION} build for ${TARGET}" \
+    --latest=false
 
 echo "Successfully created release ${RELEASE_NAME}"


### PR DESCRIPTION
## Summary

Add `--latest=false` flag to glibc artifact release creation to prevent these releases from appearing as the project's latest release on GitHub.

## Problem

The glibc build workflow creates releases for artifact storage (e.g., `glibc-2.28-20241130`), but these were appearing as the "latest" release instead of actual toolchains_cc releases, making it harder for users to find the real latest release.

## Solution

Modified `.github/workflows/build_glibc/step-7_upload_release` to include `--latest=false` flag when creating releases, ensuring glibc artifact releases don't override the visibility of actual project releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)