### PR TITLE
feat: support building multiple glibc versions in single workflow run

### DIFF
--- a/.github/workflows/build_glibc.yml
+++ b/.github/workflows/build_glibc.yml
@@ -3,26 +3,29 @@ name: Build glibc
 on:
   workflow_dispatch:
     inputs:
-      glibc_version:
-        description: 'glibc version to build (e.g., 2.28, 2.39)'
+      glibc_versions:
+        description: 'JSON array of glibc versions (e.g., ["2.28", "2.39", "2.40"])'
         required: true
+        default: '["2.39"]'
         type: string
-      target:
-        description: 'Target triple (e.g., x86_64-linux-gnu)'
-        required: false
-        type: string
-        default: 'x86_64-linux-gnu'
 
 env:
   SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_glibc
-  GLIBC_VERSION: ${{ inputs.glibc_version }}
-  TARGET: ${{ inputs.target }}
+  TARGET: x86_64-linux-gnu
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        glibc_version: ${{ fromJson(github.event.inputs.glibc_versions) }}
+      fail-fast: false
+
     permissions:
       contents: write
+
+    env:
+      GLIBC_VERSION: ${{ matrix.glibc_version }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Enables the `build_glibc` workflow to accept a JSON array of glibc versions, allowing multiple versions to be built in a single workflow run using GitHub Actions matrix strategy.

## Changes

- Modified workflow input from single `glibc_version` to `glibc_versions` JSON array
- Added matrix strategy to build versions in parallel
- Set `fail-fast: false` to ensure all versions complete even if one fails
- Hardcoded target to `x86_64-linux-gnu` (only currently supported architecture)

## Example Usage

```json
["2.28", "2.39", "2.40"]
```

## Benefits

- Eliminates need to manually trigger workflow multiple times
- Builds multiple versions in parallel for faster completion
- Simplifies maintenance of multiple glibc versions in release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)