### PR TITLE
fix: add retry logic for flaky glibc git clone

### DIFF
--- a/.github/workflows/build_glibc/step-2_download_glibc_source
+++ b/.github/workflows/build_glibc/step-2_download_glibc_source
@@ -2,6 +2,31 @@
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
 
-git clone --depth 1 \
-    --branch "glibc-${GLIBC_VERSION}" \
-    https://sourceware.org/git/glibc.git "${GLIBC_SOURCE}"
+# Retry logic for flaky git clone on GitHub Actions runners
+# https://sourceware.org sometimes has connectivity issues
+MAX_RETRIES=5
+RETRY_DELAY=5
+
+for attempt in $(seq 1 $MAX_RETRIES); do
+    echo "Attempting to clone glibc (attempt ${attempt}/${MAX_RETRIES})..."
+
+    if git clone --depth 1 \
+        --branch "glibc-${GLIBC_VERSION}" \
+        https://sourceware.org/git/glibc.git "${GLIBC_SOURCE}"; then
+        echo "Successfully cloned glibc source"
+        exit 0
+    fi
+
+    # Clean up partial clone if it exists
+    rm -rf "${GLIBC_SOURCE}"
+
+    if [ $attempt -lt $MAX_RETRIES ]; then
+        # Exponential backoff
+        sleep_time=$((RETRY_DELAY ** attempt))
+        echo "Clone failed, retrying in ${sleep_time} seconds..."
+        sleep ${sleep_time}
+    fi
+done
+
+echo "Failed to clone glibc after ${MAX_RETRIES} attempts"
+exit 1


### PR DESCRIPTION
## Summary

Adds retry logic with exponential backoff to handle intermittent connection failures when cloning glibc source from sourceware.org.

**Changes:**
- Implements 5 retry attempts with exponential backoff (5s, 25s, 125s, 625s)
- Cleans up partial clones between retry attempts
- Adds clear logging for debugging retry attempts

**Problem:**
In large matrix runs, multiple jobs fail due to connection timeouts to sourceware.org, requiring manual retry of individual steps.

**Solution:**
Exponential backoff handles transient network issues by giving increasing time for temporary problems to resolve while avoiding hammering the server.

## Test Plan

- [ ] Run build_glibc workflow with multiple matrix versions
- [ ] Verify successful clone on first attempt (normal case)
- [ ] Confirm retries work if connection fails (monitor workflow logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)