### PR TITLE
feat: enable gdbserver with static linking in binutils build

### DIFF
--- a/.github/workflows/build_binutils/step-4_build_binutils
+++ b/.github/workflows/build_binutils/step-4_build_binutils
@@ -4,14 +4,16 @@ source ${SCRIPTS_DIR}/environment
 
 pushd "${BINUTILS_SOURCE}"
 
-# --disable-gdbserver is required in addition to --disable-gdb
-# Without it, binutils-gdb still builds gdbserver by default, causing
-# linker errors with the -all-static flag (unrecognized by gcc/g++)
-
 # --with-sysroot=/: enables runtime --sysroot flag in ld without hardcoding
 # a specific path. Without this, ld rejects --sysroot with error "this linker
 # was not configured to use sysroots"
 # https://sourceware.org/binutils/docs-2.40/ld/Options.html
+
+# --disable-inprocess-agent: prevents building libinproctrace.so for gdbserver.
+# libinproctrace.so is a shared library for fast tracepoints that conflicts with
+# static linking because gdbserver uses g++ directly (not libtool) which doesn't
+# recognize the libtool-specific -all-static flag.
+# https://sourceware.org/pipermail/gdb-patches/2022-February/185721.html
 env CC_FOR_BUILD=gcc \
     CFLAGS_FOR_BUILD="-O2 -g -I${BUILD_TOOLS}/include" \
     CXXFLAGS_FOR_BUILD="-O2 -g -I${BUILD_TOOLS}/include" \
@@ -30,13 +32,31 @@ env CC_FOR_BUILD=gcc \
         --disable-gprofng \
         --disable-sim \
         --disable-gdb \
-        --disable-gdbserver \
+        --disable-inprocess-agent \
         --without-debuginfod \
         --disable-nls \
         --without-zstd
 
 make -j$(nproc) -l configure-host
-make LDFLAGS="-L${BUILD_TOOLS}/lib -all-static" -j$(nproc) -l
+
+# Build everything except gdbserver with -all-static (libtool flag)
+# gdbserver must be built separately because it uses g++ directly (not libtool),
+# which doesn't recognize -all-static and requires -static instead
+make LDFLAGS="-L${BUILD_TOOLS}/lib -all-static" -j$(nproc) -l \
+    all-binutils \
+    all-gas \
+    all-ld \
+    all-libctf \
+    all-zlib \
+    all-bfd \
+    all-opcodes \
+    all-libiberty \
+    all-libsframe \
+    all-gdbsupport
+
+# Build gdbserver with -static (gcc/g++ flag)
+make -C gdbserver LDFLAGS="-L${BUILD_TOOLS}/lib -static" -j$(nproc) -l
+
 make install
 
 popd


### PR DESCRIPTION
## Summary

Enable gdbserver in the binutils build while maintaining static linking for all binaries.

## Problem

The binutils build previously disabled gdbserver with `--disable-gdbserver` because it failed to build when using the `-all-static` linker flag.

## Root Cause

The `-all-static` flag is libtool-specific. Gdbserver's build system uses g++ directly (not through libtool), which doesn't recognize `-all-static` and produces:

```
g++: error: unrecognized command-line option '-all-static'; did you mean '--static'?
```

## Solution

This PR fixes the issue by:

1. **Adding `--disable-inprocess-agent`** to the configure flags
   - Prevents building `libinproctrace.so` (a shared library incompatible with static linking)
   - Gdbserver still functions; only fast tracepoints are unavailable

2. **Splitting the build into two phases**:
   - Build binutils tools with `-all-static` (libtool flag)
   - Build gdbserver separately with `-static` (gcc/g++ flag)

3. **Explicitly listing build targets** for precise control over which flags apply to which components

## Changes

- Modified `.github/workflows/build_binutils/step-4_build_binutils`
  - Added `--disable-inprocess-agent` to configure
  - Split `make` commands to use different LDFLAGS for different components
  - Added detailed comments explaining the libtool vs gcc flag distinction

## Verification

All binaries are now statically linked:

```
x86_64-linux-gnu-gdbserver: STATIC ✓
x86_64-linux-gnu-addr2line: STATIC ✓
x86_64-linux-gnu-ar: STATIC ✓
x86_64-linux-gnu-as: STATIC ✓
x86_64-linux-gnu-ld: STATIC ✓
x86_64-linux-gnu-nm: STATIC ✓
x86_64-linux-gnu-objcopy: STATIC ✓
x86_64-linux-gnu-objdump: STATIC ✓
x86_64-linux-gnu-ranlib: STATIC ✓
x86_64-linux-gnu-readelf: STATIC ✓
x86_64-linux-gnu-size: STATIC ✓
x86_64-linux-gnu-strings: STATIC ✓
x86_64-linux-gnu-strip: STATIC ✓
```

## References

- [How to build gdbserver as a static binary](https://sourceware.org/pipermail/gdb-patches/2022-February/185721.html)
- [Compiling static gdbserver - Stack Overflow](https://stackoverflow.com/questions/28060316/how-to-complie-a-static-gdbserver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)