### PR TITLE
fix: include all directories in glibc artifact packaging

### DIFF
--- a/.github/workflows/build_gcc.yml
+++ b/.github/workflows/build_gcc.yml
@@ -1,0 +1,76 @@
+name: Build gcc
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_pairs:
+        description: 'JSON array of version pairs (e.g., [{"gcc": "15.2.0", "glibc": "2.28"}, {"gcc": "14.2.0", "glibc": "2.34"}])'
+        required: true
+        default: '[{"gcc": "15.2.0", "glibc": "2.28"}]'
+        type: string
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_gcc
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version_pair: ${{ fromJson(github.event.inputs.version_pairs) }}
+      fail-fast: false
+
+    env:
+      GCC_VERSION: ${{ matrix.version_pair.gcc }}
+      GLIBC_VERSION: ${{ matrix.version_pair.glibc }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.0
+
+      - name: Install Dependencies
+        run: $SCRIPTS_DIR/step-01_install_dependencies
+
+      - name: Download Prebuilt Artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: $SCRIPTS_DIR/step-02_download_prebuilt_artifacts
+
+      - name: Download Source
+        run: $SCRIPTS_DIR/step-03_download_source
+
+      - name: Build GMP
+        run: $SCRIPTS_DIR/step-04_build_gmp
+
+      - name: Build MPFR
+        run: $SCRIPTS_DIR/step-05_build_mpfr
+
+      - name: Build ISL
+        run: $SCRIPTS_DIR/step-06_build_isl
+
+      - name: Build MPC
+        run: $SCRIPTS_DIR/step-07_build_mpc
+
+      - name: Build GCC
+        run: $SCRIPTS_DIR/step-08_build_gcc
+
+      - name: Package Artifacts
+        run: $SCRIPTS_DIR/step-09_package_artifacts
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v3.0.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: $SCRIPTS_DIR/step-10_upload_release

--- a/.github/workflows/build_gcc/Dockerfile
+++ b/.github/workflows/build_gcc/Dockerfile
@@ -1,0 +1,68 @@
+FROM ubuntu:latest
+
+# Build arguments for parameterizing GCC and glibc versions
+ARG GCC_VERSION=15.2.0
+ARG GLIBC_VERSION=2.28
+
+# NOTE: This Dockerfile requires GH_TOKEN to download prebuilt binutils and glibc artifacts.
+# Build with: docker build --build-arg GH_TOKEN=$GH_TOKEN ...
+
+# =================
+# || Create User ||
+# =================
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y sudo gh
+
+RUN useradd -m -s /bin/bash builder && \
+    usermod -aG sudo builder
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER builder
+WORKDIR /home/builder
+
+# =================
+# || Environment ||
+# =================
+ARG GH_TOKEN
+ENV GH_TOKEN=${GH_TOKEN}
+ENV SCRIPTS_DIR="/tmp/scripts"
+COPY environment $SCRIPTS_DIR/environment
+
+ENV GCC_VERSION=${GCC_VERSION}
+ENV GLIBC_VERSION=${GLIBC_VERSION}
+
+# =====================
+# || Build Toolchain ||
+# =====================
+COPY step-01_install_dependencies $SCRIPTS_DIR/step-01_install_dependencies
+RUN $SCRIPTS_DIR/step-01_install_dependencies
+
+COPY step-02_download_prebuilt_artifacts $SCRIPTS_DIR/step-02_download_prebuilt_artifacts
+RUN $SCRIPTS_DIR/step-02_download_prebuilt_artifacts
+
+COPY step-03_download_source $SCRIPTS_DIR/step-03_download_source
+RUN $SCRIPTS_DIR/step-03_download_source
+
+COPY step-04_build_gmp $SCRIPTS_DIR/step-04_build_gmp
+RUN $SCRIPTS_DIR/step-04_build_gmp
+
+COPY step-05_build_mpfr $SCRIPTS_DIR/step-05_build_mpfr
+RUN $SCRIPTS_DIR/step-05_build_mpfr
+
+COPY step-06_build_isl $SCRIPTS_DIR/step-06_build_isl
+RUN $SCRIPTS_DIR/step-06_build_isl
+
+COPY step-07_build_mpc $SCRIPTS_DIR/step-07_build_mpc
+RUN $SCRIPTS_DIR/step-07_build_mpc
+
+COPY step-08_build_gcc $SCRIPTS_DIR/step-08_build_gcc
+RUN $SCRIPTS_DIR/step-08_build_gcc
+
+COPY step-09_package_artifacts $SCRIPTS_DIR/step-09_package_artifacts
+RUN $SCRIPTS_DIR/step-09_package_artifacts
+
+ARG GITHUB_TOKEN
+COPY step-10_upload_release $SCRIPTS_DIR/step-10_upload_release
+RUN $SCRIPTS_DIR/step-10_upload_release
+
+# The artifact will be in /tmp/artifacts/
+# You can extract it with: docker cp <container>:/tmp/artifacts/ .

--- a/.github/workflows/build_gcc/environment
+++ b/.github/workflows/build_gcc/environment
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euox pipefail
+
+# Matrix variables from workflow
+export GCC_VERSION="${GCC_VERSION}"
+export GLIBC_VERSION="${GLIBC_VERSION}"
+
+# Hard-coded host and target (for now)
+export HOST="x86_64-linux"
+export TARGET="x86_64-linux-gnu"
+
+export SYSROOT_DIR="/tmp/sysroot"
+export BUILD_TOOLS="/tmp/buildtools"
+
+mkdir -p ${SYSROOT_DIR}
+mkdir -p ${BUILD_TOOLS}
+
+# ==============================
+# || Setup Source Directories ||
+# ==============================
+export ARTIFACTS_DIR="/tmp/artifacts"
+export GCC_ARTIFACTS="/tmp/gcc-artifacts"
+export GCC_SOURCE="/tmp/gcc-source"
+export GMP_SOURCE="/tmp/gmp-source"
+export ISL_SOURCE="/tmp/isl-source"
+export MPC_SOURCE="/tmp/mpc-source"
+export MPFR_SOURCE="/tmp/mpfr-source"
+
+mkdir -p ${ARTIFACTS_DIR}
+mkdir -p ${GCC_ARTIFACTS}
+mkdir -p ${GCC_SOURCE}
+mkdir -p ${GMP_SOURCE}
+mkdir -p ${ISL_SOURCE}
+mkdir -p ${MPC_SOURCE}
+mkdir -p ${MPFR_SOURCE}
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "${GITHUB_ENV}"
+fi

--- a/.github/workflows/build_gcc/step-01_install_dependencies
+++ b/.github/workflows/build_gcc/step-01_install_dependencies
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euox pipefail
+
+sudo apt update
+DEBIAN_FRONTEND=noninteractive sudo apt install -y \
+    build-essential \
+    autoconf \
+    flex \
+    bison \
+    texinfo \
+    help2man \
+    file \
+    gawk \
+    libtool \
+    libtool-bin \
+    libncurses-dev \
+    python3 \
+    python3-dev \
+    unzip \
+    git \
+    wget \
+    curl \
+    rsync \
+    jq

--- a/.github/workflows/build_gcc/step-02_download_prebuilt_artifacts
+++ b/.github/workflows/build_gcc/step-02_download_prebuilt_artifacts
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+DOWNLOAD_DIR="/tmp/downloads"
+mkdir -p ${DOWNLOAD_DIR}
+
+# ===================
+# || Find Binutils ||
+# ===================
+# Release name format: {host}-{target}-binutils-{version}-{date}
+# Tag name format: binutils-{version}-{date}
+# Artifact format: {host}-{target}-binutils-{version}-{date}.tar.xz
+
+# Find the latest binutils release for our host and target
+# We filter by release name but extract the tagName for downloading
+BINUTILS_INFO=$(gh release list \
+    --repo reutermj/toolchains_cc \
+    --limit 1000 \
+    --json tagName,name,createdAt \
+    | jq -r '.[] | select(.name | startswith("'${HOST}'-'${TARGET}'-binutils-")) | {tagName, name}' \
+    | jq -s 'sort_by(.name) | last')
+
+BINUTILS_TAG=$(echo "$BINUTILS_INFO" | jq -r '.tagName')
+BINUTILS_NAME=$(echo "$BINUTILS_INFO" | jq -r '.name')
+
+if [ -z "$BINUTILS_TAG" ] || [ "$BINUTILS_TAG" == "null" ]; then
+    echo "ERROR: No binutils release found for ${HOST}-${TARGET}"
+    exit 1
+fi
+
+echo "Found binutils release: ${BINUTILS_NAME} (tag: ${BINUTILS_TAG})"
+
+# Download binutils artifact
+gh release download "${BINUTILS_TAG}" \
+    --repo reutermj/toolchains_cc \
+    --pattern "${BINUTILS_NAME}.tar.xz" \
+    --dir "${DOWNLOAD_DIR}"
+
+# Extract binutils into sysroot
+tar xf "${DOWNLOAD_DIR}/${BINUTILS_NAME}.tar.xz" -C "${SYSROOT_DIR}"
+
+# ================
+# || Find glibc ||
+# ================
+# Release tag format: glibc-{version}-{date}
+# Artifact format: {target}-glibc-{version}-{date}.tar.xz
+
+# Find the latest glibc release matching the glibc version
+GLIBC_TAG=$(gh release list \
+    --repo reutermj/toolchains_cc \
+    --limit 1000 \
+    --json tagName,createdAt \
+    | jq -r '.[] | select(.tagName | startswith("glibc-'${GLIBC_VERSION}'-")) | .tagName' \
+    | sort -V \
+    | tail -n 1)
+
+if [ -z "$GLIBC_TAG" ]; then
+    echo "ERROR: No glibc release found for version ${GLIBC_VERSION}"
+    exit 1
+fi
+
+echo "Found glibc release: ${GLIBC_TAG}"
+
+# The artifact name includes the target
+GLIBC_ARTIFACT="${TARGET}-${GLIBC_TAG}.tar.xz"
+
+# Download glibc artifact
+gh release download "${GLIBC_TAG}" \
+    --repo reutermj/toolchains_cc \
+    --pattern "${GLIBC_ARTIFACT}" \
+    --dir "${DOWNLOAD_DIR}"
+
+# Extract glibc into sysroot
+tar xf "${DOWNLOAD_DIR}/${GLIBC_ARTIFACT}" -C "${SYSROOT_DIR}"
+
+echo "Sysroot prepared at ${SYSROOT_DIR}"
+ls -la "${SYSROOT_DIR}"

--- a/.github/workflows/build_gcc/step-03_download_source
+++ b/.github/workflows/build_gcc/step-03_download_source
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+TARBALLS="/tmp/tarballs"
+mkdir -p ${TARBALLS}
+
+# =========
+# || gcc ||
+# =========
+GCC_VERSION_UNDERSCORES="${GCC_VERSION//./_}"
+git clone --depth 1 \
+    --branch "releases/gcc-${GCC_VERSION}" \
+    git://gcc.gnu.org/git/gcc.git "${GCC_SOURCE}"
+
+# =========
+# || gmp ||
+# =========
+# gmplib.org is unreliable when running on GitHub Actions runners.
+# Downloading from our vendored dependencies release instead.
+# See: https://github.com/reutermj/toolchains_cc/releases/tag/dependencies-v1
+GMP_TARBALL="${TARBALLS}/gmp.tar.xz"
+GMP_VERSION="6.3.0"
+GMP_URL="https://github.com/reutermj/toolchains_cc/releases/download/dependencies-v1/gmp-${GMP_VERSION}.tar.xz"
+wget -O "${GMP_TARBALL}" "${GMP_URL}"
+tar xvf "${GMP_TARBALL}" -C "${GMP_SOURCE}" --strip-components=1
+
+# =========
+# || isl ||
+# =========
+ISL_VERSION="0.27"
+git clone --depth 1 \
+    --branch "isl-${ISL_VERSION}" \
+    https://repo.or.cz/isl.git "${ISL_SOURCE}"
+
+# =========
+# || mpc ||
+# =========
+MPC_VERSION="1.3.1"
+git clone --depth 1 \
+    --branch "${MPC_VERSION}" \
+    https://gitlab.inria.fr/mpc/mpc.git "${MPC_SOURCE}"
+
+# ==========
+# || mpfr ||
+# ==========
+MPFR_VERSION="4.2.2"
+git clone --depth 1 \
+    --branch "${MPFR_VERSION}" \
+    https://gitlab.inria.fr/mpfr/mpfr.git "${MPFR_SOURCE}"

--- a/.github/workflows/build_gcc/step-04_build_gmp
+++ b/.github/workflows/build_gcc/step-04_build_gmp
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${GMP_SOURCE}"
+
+env CC_FOR_BUILD=gcc \
+    CPP_FOR_BUILD=cpp \
+    CC=gcc \
+    CFLAGS='-O2 -g -pipe -I${BUILD_TOOLS}/include -std=gnu17 -fexceptions' \
+    LDFLAGS='-L${BUILD_TOOLS}/lib' \
+    ./configure \
+        --build=x86_64-build_pc-linux-gnu \
+        --host=x86_64-build_pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --enable-fft \
+        --enable-cxx \
+        --disable-shared \
+        --enable-static
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_gcc/step-05_build_mpfr
+++ b/.github/workflows/build_gcc/step-05_build_mpfr
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${MPFR_SOURCE}"
+
+./autogen.sh
+
+env CC=gcc \
+    CFLAGS='-O2 -g -pipe -I${BUILD_TOOLS}/include' \
+    LDFLAGS='-L${BUILD_TOOLS}/lib' \
+    ./configure \
+        --build=x86_64-build_pc-linux-gnu \
+        --host=x86_64-build_pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --with-gmp="${BUILD_TOOLS}" \
+        --enable-thread-safe \
+        --disable-shared \
+        --enable-static
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_gcc/step-06_build_isl
+++ b/.github/workflows/build_gcc/step-06_build_isl
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${ISL_SOURCE}"
+
+./autogen.sh
+
+env CC=gcc \
+    CFLAGS='-O2 -g -pipe -I${BUILD_TOOLS}/include' \
+    CXXFLAGS='-O2 -g -pipe -I${BUILD_TOOLS}/include' \
+    LDFLAGS='-L${BUILD_TOOLS}/lib' \
+    ./configure \
+        --build=x86_64-build_pc-linux-gnu \
+        --host=x86_64-build_pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --with-gmp=system \
+        --with-gmp-prefix="${BUILD_TOOLS}" \
+        --enable-thread-safe \
+        --disable-shared \
+        --enable-static \
+        --with-clang=no
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_gcc/step-07_build_mpc
+++ b/.github/workflows/build_gcc/step-07_build_mpc
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${MPC_SOURCE}"
+
+autoreconf -i
+
+env CC=gcc \
+    CFLAGS='-O2 -g -pipe -I${BUILD_TOOLS}/include' \
+    CXXFLAGS='-O2 -g -pipe -I${BUILD_TOOLS}/include' \
+    LDFLAGS='-L${BUILD_TOOLS}/lib' \
+    ./configure \
+        --build=x86_64-build_pc-linux-gnu \
+        --host=x86_64-build_pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --with-gmp="${BUILD_TOOLS}" \
+        --with-mpfr="${BUILD_TOOLS}" \
+        --disable-shared \
+        --enable-static
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_gcc/step-08_build_gcc
+++ b/.github/workflows/build_gcc/step-08_build_gcc
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+GCC_BUILD_DIR=/tmp/gcc-build/
+mkdir -p ${GCC_BUILD_DIR}
+
+pushd "${GCC_BUILD_DIR}"
+
+# Build GCC using the prebuilt sysroot containing binutils and glibc
+# --with-build-sysroot allows using a sysroot at build time without hardcoding the path
+# At runtime, users can specify --sysroot to use a different location
+env CC_FOR_BUILD="gcc" \
+    CFLAGS="-O2 -g -pipe -I${BUILD_TOOLS}/include" \
+    CFLAGS_FOR_BUILD="-O2 -g -pipe -I${BUILD_TOOLS}/include" \
+    CXXFLAGS="-O2 -g -pipe -I${BUILD_TOOLS}/include" \
+    CXXFLAGS_FOR_BUILD="-O2 -g -pipe -I${BUILD_TOOLS}/include" \
+    LDFLAGS="-L${BUILD_TOOLS}/lib -static" \
+    CFLAGS_FOR_TARGET="-g -O2" \
+    CXXFLAGS_FOR_TARGET="-g -O2" \
+    LDFLAGS_FOR_TARGET="" \
+    ${GCC_SOURCE}/configure \
+        --build=x86_64-build_pc-linux-gnu \
+        --host=x86_64-build_pc-linux-gnu \
+        --target=${TARGET} \
+        --with-sysroot="${SYSROOT_DIR}" \
+        --with-native-system-header-dir=/usr/include \
+        --enable-languages=c,c++ \
+        --enable-__cxa_atexit \
+        --disable-libmudflap \
+        --disable-libgomp \
+        --disable-libssp \
+        --disable-libquadmath \
+        --disable-libquadmath-support \
+        --disable-libsanitizer \
+        --enable-libmpx \
+        --with-gmp="${BUILD_TOOLS}" \
+        --with-mpfr="${BUILD_TOOLS}" \
+        --with-mpc="${BUILD_TOOLS}" \
+        --with-isl="${BUILD_TOOLS}" \
+        --enable-lto \
+        --enable-threads=posix \
+        --enable-target-optspace \
+        --with-linker-hash-style=both \
+        --disable-plugin \
+        --disable-nls \
+        --disable-multilib \
+        --enable-long-long
+
+make -j$(nproc) -l all
+make install prefix="${GCC_ARTIFACTS}" exec_prefix="${GCC_ARTIFACTS}"
+
+MESSAGE="See https://github.com/reutermj/toolchains_cc/blob/main/docs/lore/gcc/load_bearing_directories.md"
+echo ${MESSAGE} > ${GCC_ARTIFACTS}/lib/keep_load_bearing_directory
+
+popd

--- a/.github/workflows/build_gcc/step-09_package_artifacts
+++ b/.github/workflows/build_gcc/step-09_package_artifacts
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${GCC_ARTIFACTS}"
+GCC_FULL_VERSION=$("bin/${TARGET}-gcc" --version | head -n1 | awk '{print $NF}')
+DATETIME=$(date +%Y%m%d)
+RELEASE_NAME="${HOST}-${TARGET}-glibc-${GLIBC_VERSION}-gcc-${GCC_FULL_VERSION}-${DATETIME}"
+echo $RELEASE_NAME > release_name
+
+# =======================
+# || Package libstdc++ ||
+# =======================
+cp -r share share-libstdcxx
+
+LIBSTDCXX_FILES=()
+LIBSTDCXX_FILES+=(share-libstdcxx)
+LIBSTDCXX_FILES+=("${TARGET}/include/c++/")
+LIBSTDCXX_FILES+=("${TARGET}/lib64/libitm"*)
+LIBSTDCXX_FILES+=("${TARGET}/lib64/libstdc++"*)
+LIBSTDCXX_FILES+=("${TARGET}/lib64/libsupc++"*)
+
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${TARGET}-glibc-${GLIBC_VERSION}-libstdcxx-${GCC_FULL_VERSION}-${DATETIME}.tar.xz" \
+    "${LIBSTDCXX_FILES[@]}"
+
+rm -rf "${LIBSTDCXX_FILES[@]}"
+
+# =======================================
+# || Package gcc compiler runtime libs ||
+# =======================================
+cp -r share share-libgcc
+
+LIBGCC_FILES=()
+LIBGCC_FILES+=(share-libgcc)
+LIBGCC_FILES+=(lib/gcc)
+LIBGCC_FILES+=("${TARGET}/lib64/libgcc"*)
+LIBGCC_FILES+=("${TARGET}/lib64/libatomic"*)
+
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${TARGET}-glibc-${GLIBC_VERSION}-libgcc-${GCC_FULL_VERSION}-${DATETIME}.tar.xz" \
+    "${LIBGCC_FILES[@]}"
+
+rm -rf "${LIBGCC_FILES[@]}"
+
+# =================
+# || Package gcc ||
+# =================
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${RELEASE_NAME}.tar.xz" \
+    bin/ \
+    lib/ \
+    libexec/ \
+    share/ \
+    "${TARGET}"
+
+popd

--- a/.github/workflows/build_gcc/step-10_upload_release
+++ b/.github/workflows/build_gcc/step-10_upload_release
@@ -1,0 +1,17 @@
+#!/bin/bash
+source ${SCRIPTS_DIR}/environment
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "GITHUB_TOKEN is not set, exiting"
+    exit 0
+fi
+
+GCC_FULL_VERSION=$("${GCC_ARTIFACTS}/bin/${TARGET}-gcc" --version | head -n1 | awk '{print $NF}')
+RELEASE_NAME=$(cat ${GCC_ARTIFACTS}/release_name)
+
+gh release create "${RELEASE_NAME}" \
+    ${ARTIFACTS_DIR}/*.tar.xz \
+    --repo=https://github.com/reutermj/toolchains_cc \
+    --latest=false \
+    --title="${RELEASE_NAME}" \
+    --notes="GCC ${GCC_FULL_VERSION} toolchain for ${HOST} host targeting ${TARGET} with glibc ${GLIBC_VERSION}"

--- a/.github/workflows/build_glibc/step-6_package_glibc
+++ b/.github/workflows/build_glibc/step-6_package_glibc
@@ -13,6 +13,6 @@ RELEASE_NAME="glibc-${GLIBC_VERSION}-${DATETIME}"
 # Save release name for upload step
 echo "${RELEASE_NAME}" > "${ARTIFACTS_DIR}/release_name"
 
-XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" usr/
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
 
 popd


### PR DESCRIPTION
## Summary

- Fixes glibc artifact packaging to include all directories (lib64/, usr/, etc.) instead of just usr/
- This resolves linker errors when using glibc artifacts as a sysroot in downstream builds like the GCC workflow

## Context

The glibc packaging step was only including the `usr/` directory in the artifact tarball. However, glibc installs files to multiple directories including `lib64/` which contains actual shared libraries (.so.6 files). The `usr/lib64/` directory contains linker scripts and symlinks that reference `../../lib64/libc.so.6`, but those targets were missing from the extracted sysroot.

## Changes

Changed [.github/workflows/build_glibc/step-6_package_glibc](.github/workflows/build_glibc/step-6_package_glibc#L16):
```diff
-XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" usr/
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
```

## Test Plan

- [x] Built GCC workflow with fixed glibc artifact
- [x] Verified linker can find lib64/libc.so.6 and other shared libraries
- [x] Confirmed no "cannot find /lib64/libc.so.6 inside /tmp/sysroot" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)