### PR TITLE
fix: include all directories in glibc artifact packaging

### DIFF
--- a/.github/workflows/build_glibc/step-6_package_glibc
+++ b/.github/workflows/build_glibc/step-6_package_glibc
@@ -13,6 +13,6 @@ RELEASE_NAME="glibc-${GLIBC_VERSION}-${DATETIME}"
 # Save release name for upload step
 echo "${RELEASE_NAME}" > "${ARTIFACTS_DIR}/release_name"
 
-XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" usr/
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
 
 popd


### PR DESCRIPTION
## Summary

- Fixes glibc artifact packaging to include all directories (lib64/, usr/, etc.) instead of just usr/
- This resolves linker errors when using glibc artifacts as a sysroot in downstream builds like the GCC workflow

## Context

The glibc packaging step was only including the `usr/` directory in the artifact tarball. However, glibc installs files to multiple directories including `lib64/` which contains actual shared libraries (.so.6 files). The `usr/lib64/` directory contains linker scripts and symlinks that reference `../../lib64/libc.so.6`, but those targets were missing from the extracted sysroot.

## Changes

Changed [.github/workflows/build_glibc/step-6_package_glibc](.github/workflows/build_glibc/step-6_package_glibc#L16):
```diff
-XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" usr/
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
```

## Test Plan

- [x] Built GCC workflow with fixed glibc artifact
- [x] Verified linker can find lib64/libc.so.6 and other shared libraries
- [x] Confirmed no "cannot find /lib64/libc.so.6 inside /tmp/sysroot" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)