### PR TITLE
Consolidate glibc releases into single Toolchain Binaries release

### DIFF
--- a/.github/workflows/build_glibc/step-6_package_glibc
+++ b/.github/workflows/build_glibc/step-6_package_glibc
@@ -4,6 +4,13 @@ source ${SCRIPTS_DIR}/environment
 
 pushd "${GLIBC_ARTIFACTS}"
 
+mkdir lib
+mkdir usr/lib
+
+MESSAGE="See https://github.com/reutermj/toolchains_cc/blob/main/docs/lore/gcc/load_bearing_directories.md"
+echo ${MESSAGE} > lib/keep_load_bearing_directory
+echo ${MESSAGE} > usr/lib/keep_load_bearing_directory
+
 # Package format: <target>-glibc-<version>-<datetime>.tar.xz
 # Example: x86_64-linux-gnu-glibc-2.28-20241130.tar.xz
 DATETIME=$(date +%Y%m%d)

--- a/.github/workflows/build_glibc/step-7_upload_release
+++ b/.github/workflows/build_glibc/step-7_upload_release
@@ -7,15 +7,11 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     exit 0
 fi
 
-# Release name format: glibc-<version>-<datetime>
-# Example: glibc-2.28-20241130
-RELEASE_NAME=$(cat "${ARTIFACTS_DIR}/release_name")
+RELEASE_TAG="binaries"
 
-echo "Creating release ${RELEASE_NAME}"
-gh release create "${RELEASE_NAME}" \
+echo "Uploading artifacts to release ${RELEASE_TAG}"
+gh release upload "${RELEASE_TAG}" \
     ${ARTIFACTS_DIR}/*.tar.xz \
-    --title "${RELEASE_NAME}" \
-    --notes "glibc ${GLIBC_VERSION} build for ${TARGET}" \
-    --latest=false
+    --clobber
 
-echo "Successfully created release ${RELEASE_NAME}"
+echo "Successfully uploaded artifacts to release ${RELEASE_TAG}"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 18,
+  "lockFileVersion": 24,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -34,8 +34,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1/MODULE.bazel": "57f2736616367163651d9d3e918cddfd6c67ec7a541d924f2c4544d3fae8630e",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1/source.json": "a3e79a347f9d8256d83eba2b621b5b6affa17c8b3236127f030db03b72a44a91",
+    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/MODULE.bazel": "2e2e306add04b7c7cd21e73c9293dcbd7528a08a84338e919036f402eb6b1e2e",
+    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/source.json": "4c86fd3a384a09613c2213fb1f71562d6d70471977e6e81173e6625fd6ce53bc",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
@@ -141,94 +141,6 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {
-    "//:extensions.bzl%cc_toolchains": {
-      "general": {
-        "bzlTransitiveDigest": "YqAiV1HDP7cQxl16kJMONjVT3FCsJqrwg4/LIpRhOfQ=",
-        "usagesDigest": "7+3J5gmi+d+KlB1uusu0Wp3basxcsSRjG6ifUdhBICo=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "toolchains_cc_default_toolchain": {
-            "repoRuleId": "@@//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
-            "attributes": {
-              "toolchain_name": "toolchains_cc"
-            }
-          },
-          "toolchains_cc_default_toolchain_bins": {
-            "repoRuleId": "@@//private:lazy_download_bins.bzl%lazy_download_bins",
-            "attributes": {
-              "toolchain_name": "toolchains_cc"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
-      "general": {
-        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
-        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "com_github_jetbrains_kotlin_git": {
-            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
-            "attributes": {
-              "urls": [
-                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
-              ],
-              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
-            }
-          },
-          "com_github_jetbrains_kotlin": {
-            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
-            "attributes": {
-              "git_repository_name": "com_github_jetbrains_kotlin_git",
-              "compiler_version": "1.9.23"
-            }
-          },
-          "com_github_google_ksp": {
-            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
-            "attributes": {
-              "urls": [
-                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
-              ],
-              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
-              "strip_version": "1.9.23-1.0.20"
-            }
-          },
-          "com_github_pinterest_ktlint": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
-              "urls": [
-                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
-              ],
-              "executable": true
-            }
-          },
-          "rules_android": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-              "strip_prefix": "rules_android-0.1.1",
-              "urls": [
-                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_kotlin+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    }
-  }
+  "moduleExtensions": {},
+  "facts": {}
 }


### PR DESCRIPTION
## Summary

- Modified glibc build workflow to upload artifacts to a single persistent "Toolchain Binaries" release instead of creating new dated releases for each build
- This keeps the releases page clean and makes toolchain binaries easier to find at a known location (tag: `binaries`)

## Changes

- [step-7_upload_release](.github/workflows/build_glibc/step-7_upload_release): Changed from `gh release create` to `gh release upload` with fixed tag "binaries" and added `--clobber` flag to allow overwriting artifacts during rebuilds
- [step-6_package_glibc](.github/workflows/build_glibc/step-6_package_glibc): Added load_bearing_directories to lib/ and usr/lib/

## Test plan

- [ ] Run glibc build workflow and verify artifacts upload to "Toolchain Binaries" release
- [ ] Verify `--clobber` flag works when rebuilding same glibc version on same day
- [ ] Confirm releases page is no longer cluttered with dated releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)