### PR TITLE
Consolidate binutils releases into single Toolchain Binaries release

### DIFF
--- a/.github/workflows/build_binutils/step-6_upload_release
+++ b/.github/workflows/build_binutils/step-6_upload_release
@@ -7,15 +7,11 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     exit 0
 fi
 
-# Release name format: binutils-<version>-<datetime>
-# Example: binutils-2.43-20241201
-RELEASE_NAME=$(cat "${ARTIFACTS_DIR}/release_name")
+RELEASE_TAG="binaries"
 
-echo "Creating release ${RELEASE_NAME}"
-gh release create "${RELEASE_NAME}" \
+echo "Uploading artifacts to release ${RELEASE_TAG}"
+gh release upload "${RELEASE_TAG}" \
     ${ARTIFACTS_DIR}/*.tar.xz \
-    --title "${RELEASE_NAME}" \
-    --notes "binutils ${BINUTILS_VERSION} build for ${TARGET}" \
-    --latest=false
+    --clobber
 
-echo "Successfully created release ${RELEASE_NAME}"
+echo "Successfully uploaded artifacts to release ${RELEASE_TAG}"


### PR DESCRIPTION
## Summary

- Modified binutils build workflow to upload artifacts to a single persistent "Toolchain Binaries" release instead of creating new dated releases for each build
- This keeps the releases page clean and makes toolchain binaries easier to find at a known location (tag: `binaries`)

## Changes

- [step-6_upload_release](.github/workflows/build_binutils/step-6_upload_release): Changed from `gh release create` to `gh release upload` with fixed tag "binaries" and added `--clobber` flag to allow overwriting artifacts during rebuilds

## Test plan

- [ ] Run binutils build workflow and verify artifacts upload to "Toolchain Binaries" release
- [ ] Verify `--clobber` flag works when rebuilding same binutils version on same day
- [ ] Confirm releases page is no longer cluttered with dated releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)