### PR TITLE
feat: add workflow for creating attested source tarballs

### DIFF
--- a/.github/workflows/create_source_tarballs.yml
+++ b/.github/workflows/create_source_tarballs.yml
@@ -1,0 +1,66 @@
+name: Create Source Tarballs
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to download (binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc)'
+        required: true
+        type: choice
+        options:
+          - binutils
+          - zlib
+          - glibc
+          - linux
+          - gmp
+          - mpfr
+          - isl
+          - mpc
+          - gcc
+      version:
+        description: 'Version to download (e.g., 2.43.1 for binutils, 15.2.0 for gcc)'
+        required: true
+        type: string
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/create_source_tarballs
+  COMPONENT: ${{ github.event.inputs.component }}
+  VERSION: ${{ github.event.inputs.version }}
+
+jobs:
+  create-source-tarballs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.1
+
+      - name: Install dependencies
+        run: $SCRIPTS_DIR/step-1_install_dependencies
+
+      - name: Set up environment
+        run: $SCRIPTS_DIR/environment
+
+      - name: Download source
+        run: $SCRIPTS_DIR/step-2_download_source
+
+      - name: Create source tarball
+        run: $SCRIPTS_DIR/step-3_create_tarball
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v3.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: $SCRIPTS_DIR/step-4_upload_release

--- a/.github/workflows/create_source_tarballs/Dockerfile
+++ b/.github/workflows/create_source_tarballs/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:latest
+
+ARG COMPONENT=gcc
+ARG VERSION=15.2.0
+
+# =================
+# || Create User ||
+# =================
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y sudo gh
+
+RUN useradd -m -s /bin/bash builder && \
+    usermod -aG sudo builder
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER builder
+WORKDIR /home/builder
+
+# =================
+# || Environment ||
+# =================
+ENV SCRIPTS_DIR="/tmp/scripts"
+COPY environment $SCRIPTS_DIR/environment
+
+ENV COMPONENT=${COMPONENT}
+ENV VERSION=${VERSION}
+
+# ============================
+# || Create Source Tarballs ||
+# ============================
+COPY step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
+RUN $SCRIPTS_DIR/step-1_install_dependencies
+
+COPY step-2_download_source $SCRIPTS_DIR/step-2_download_source
+RUN $SCRIPTS_DIR/step-2_download_source
+
+COPY step-3_create_tarball $SCRIPTS_DIR/step-3_create_tarball
+RUN $SCRIPTS_DIR/step-3_create_tarball

--- a/.github/workflows/create_source_tarballs/environment
+++ b/.github/workflows/create_source_tarballs/environment
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euox pipefail
+
+# Directory structure
+export SOURCES_DIR="/tmp/sources"
+export ARTIFACTS_DIR="/tmp/artifacts"
+
+# Source directory for the specified component
+export SOURCE_DIR="${SOURCES_DIR}/${COMPONENT}"
+
+# Create directory structure
+mkdir -p "${SOURCES_DIR}"
+mkdir -p "${ARTIFACTS_DIR}"
+mkdir -p "${SOURCE_DIR}"
+
+# Export to GitHub Actions environment if running in CI
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "${GITHUB_ENV}"
+fi
+
+# Retry function with exponential backoff for flaky network operations
+# Usage: retry_with_backoff <cleanup_path> <command> [args...]
+retry_with_backoff() {
+    local cleanup_path="$1"
+    shift
+    local max_retries=8
+    local retry_delay=2
+
+    for attempt in $(seq 1 $max_retries); do
+        echo "Attempt ${attempt}/${max_retries}: $@"
+
+        if "$@"; then
+            echo "Success: $@"
+            return 0
+        fi
+
+        # Clean up partial state if path provided
+        if [ -n "$cleanup_path" ] && [ -e "$cleanup_path" ]; then
+            rm -rf "$cleanup_path"
+        fi
+
+        if [ $attempt -lt $max_retries ]; then
+            local sleep_time=$((retry_delay ** attempt))
+            echo "Failed, retrying in ${sleep_time} seconds..."
+            sleep ${sleep_time}
+        fi
+    done
+
+    echo "Failed after ${max_retries} attempts: $@"
+    return 1
+}

--- a/.github/workflows/create_source_tarballs/step-1_install_dependencies
+++ b/.github/workflows/create_source_tarballs/step-1_install_dependencies
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euox pipefail
+
+sudo apt-get update
+sudo apt-get install -y \
+    git \
+    wget \
+    xz-utils

--- a/.github/workflows/create_source_tarballs/step-2_download_source
+++ b/.github/workflows/create_source_tarballs/step-2_download_source
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+case "${COMPONENT}" in
+    binutils)
+        VERSION_UNDERSCORES="${VERSION//./_}"
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "binutils-${VERSION_UNDERSCORES}-branch" \
+                git://sourceware.org/git/binutils-gdb.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    zlib)
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "v${VERSION}" \
+                https://github.com/madler/zlib.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    glibc)
+        # https://sourceware.org sometimes has connectivity issues
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "glibc-${VERSION}" \
+                https://sourceware.org/git/glibc.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    linux)
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "v${VERSION}" \
+                https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    gmp)
+        # Download from GNU mirror (more reliable than gmplib.org)
+        TARBALL="/tmp/gmp-${VERSION}.tar.xz"
+        retry_with_backoff "${TARBALL}" \
+            wget -O "${TARBALL}" "https://ftp.gnu.org/gnu/gmp/gmp-${VERSION}.tar.xz"
+        tar xf "${TARBALL}" -C "${SOURCE_DIR}" --strip-components=1
+        rm "${TARBALL}"
+        ;;
+
+    mpfr)
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "${VERSION}" \
+                https://gitlab.inria.fr/mpfr/mpfr.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    isl)
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "isl-${VERSION}" \
+                https://repo.or.cz/isl.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    mpc)
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "${VERSION}" \
+                https://gitlab.inria.fr/mpc/mpc.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    gcc)
+        retry_with_backoff "${SOURCE_DIR}" \
+            git clone --depth 1 \
+                --branch "releases/gcc-${VERSION}" \
+                git://gcc.gnu.org/git/gcc.git "${SOURCE_DIR}"
+        rm -rf "${SOURCE_DIR}/.git"
+        ;;
+
+    *)
+        echo "ERROR: Unknown component '${COMPONENT}'"
+        echo "Valid components: binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc"
+        exit 1
+        ;;
+esac

--- a/.github/workflows/create_source_tarballs/step-3_create_tarball
+++ b/.github/workflows/create_source_tarballs/step-3_create_tarball
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${SOURCE_DIR}"
+XZ_OPT=-e9 tar -cJf "${ARTIFACTS_DIR}/${COMPONENT}-${VERSION}.tar.xz" .
+popd

--- a/.github/workflows/create_source_tarballs/step-4_upload_release
+++ b/.github/workflows/create_source_tarballs/step-4_upload_release
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "GITHUB_TOKEN is not set, exiting"
+    exit 0
+fi
+
+gh release upload sources \
+    ${ARTIFACTS_DIR}/*.tar.xz \
+    --clobber


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that creates attested source tarballs for toolchain components on-demand.

## Problem

Downloading source tarballs from upstream has been unreliable, causing build failures and blocking reproducible builds.

## Solution

- Manual workflow with component/version inputs
- Downloads and packages 9 components: binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc
- Removes .git directories for clean source tarballs
- Generates build provenance attestations
- Uploads to separate "sources" release

## Testing

Includes Dockerfile for local testing:
```bash
cd .github/workflows/create_source_tarballs
docker build --build-arg COMPONENT=gcc --build-arg VERSION=15.2.0 -f Dockerfile .
```

## Notes

- Created "sources" release tag on first commit (5029c98)
- GNU FTP mirror used for GMP due to gmplib.org reliability issues
- Tarballs extract directly to current directory (no top-level folder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)