### PR TITLE
chore: automate glibc Docker artifact extraction

### DIFF
--- a/.github/workflows/build_glibc.yml
+++ b/.github/workflows/build_glibc.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Download glibc source
         run: ${{ env.SCRIPTS_DIR }}/step-2.1_download_glibc_source
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Download Linux kernel headers source
         run: ${{ env.SCRIPTS_DIR }}/step-2.2_download_linux_source
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Install Linux kernel headers
         run: ${{ env.SCRIPTS_DIR }}/step-3_install_linux_headers

--- a/.github/workflows/build_glibc/Dockerfile
+++ b/.github/workflows/build_glibc/Dockerfile
@@ -51,6 +51,3 @@ RUN $SCRIPTS_DIR/step-4_build_glibc
 
 COPY .github/workflows/build_glibc/step-5_package_glibc $SCRIPTS_DIR/step-5_package_glibc
 RUN $SCRIPTS_DIR/step-5_package_glibc
-
-# The artifact will be in /tmp/artifacts/
-# You can extract it with: docker cp <container>:/tmp/artifacts/ .

--- a/.github/workflows/build_glibc/build.sh
+++ b/.github/workflows/build_glibc/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euox pipefail
+
+# Usage: Run from repo root with GitHub token
+#   .github/workflows/build_glibc/build.sh <GH_TOKEN>
+
+docker build \
+    -f .github/workflows/build_glibc/Dockerfile \
+    --build-arg GH_TOKEN=$1 \
+    -t glibc \
+    .
+
+CONTAINER_ID=$(docker create glibc)
+docker cp "${CONTAINER_ID}:/tmp/artifacts/." ./artifacts/
+docker rm "${CONTAINER_ID}"

--- a/.github/workflows/build_glibc/build_dockerfile
+++ b/.github/workflows/build_glibc/build_dockerfile
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-docker build \
-    -f .github/workflows/build_glibc/Dockerfile \
-    --build-arg GH_TOKEN=$1 \
-    -t glibc \
-    .

--- a/.github/workflows/build_glibc/step-4_build_glibc
+++ b/.github/workflows/build_glibc/step-4_build_glibc
@@ -7,8 +7,9 @@ mkdir -p "${GLIBC_BUILD_DIR}"
 
 pushd "${GLIBC_BUILD_DIR}"
 
-# Build glibc using host GCC
-# Unlike the bootstrap approach, we use the system GCC directly
+# ===============
+# || Configure ||
+# ===============
 env BUILD_CC=gcc \
     CC="gcc -g -O2 -fcommon -U_FORTIFY_SOURCE -Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-implicit-int -fcf-protection=none" \
     CFLAGS="-fcf-protection=none" \
@@ -32,6 +33,9 @@ env BUILD_CC=gcc \
         --enable-add-ons=no \
         --disable-werror
 
+# ===========
+# || Build ||
+# ===========
 make -j$(nproc) -l \
     CXX="" \
     LDFLAGS="" \
@@ -41,7 +45,9 @@ make -j$(nproc) -l \
     BUILD_LDFLAGS="" \
     all
 
-# Install to GLIBC_ARTIFACTS for packaging
+# =============
+# || Install ||
+# =============
 make -j$(nproc) -l \
     CXX="" \
     default_cflags="" \

--- a/.github/workflows/build_glibc/step-5_package_glibc
+++ b/.github/workflows/build_glibc/step-5_package_glibc
@@ -15,10 +15,6 @@ echo ${MESSAGE} > usr/lib/keep_load_bearing_directory
 # Example: x86_64-linux-gnu-glibc-2.28-20241130.tar.xz
 DATETIME=$(date +%Y%m%d)
 PACKAGE_NAME="x86_64-linux-gnu-glibc-${GLIBC_VERSION}-${DATETIME}.tar.xz"
-RELEASE_NAME="glibc-${GLIBC_VERSION}-${DATETIME}"
-
-# Save release name for upload step
-echo "${RELEASE_NAME}" > "${ARTIFACTS_DIR}/release_name"
 
 XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
 


### PR DESCRIPTION
## Summary

Simplifies the local glibc Docker build workflow by automating artifact extraction and cleaning up unused code.

## Changes

- **Automated extraction**: Build script now automatically extracts artifacts from Docker container to `./artifacts/`
- **Script rename**: `build_dockerfile` → `build.sh` for clarity
- **Cleanup**: Removed unused release_name generation from packaging step
- **Best practices**: Updated workflow to use `github.token` instead of `secrets.GITHUB_TOKEN`
- **Organization**: Added section headers to build script for better readability

## Test Plan

- [x] Verified build.sh extracts artifacts to `./artifacts/` directory
- [x] Confirmed artifact extraction works correctly
- [x] Checked that unused release_name generation is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)