### PR TITLE
feat: add musl to source tarballs workflow

### DIFF
--- a/.github/workflows/create_source_tarballs.yml
+++ b/.github/workflows/create_source_tarballs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       component:
-        description: 'Component to download (binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc)'
+        description: 'Component to download (binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc, musl)'
         required: true
         type: choice
         options:
@@ -17,6 +17,7 @@ on:
           - isl
           - mpc
           - gcc
+          - musl
       version:
         description: 'Version to download (e.g., 2.43.1 for binutils, 15.2.0 for gcc)'
         required: true

--- a/.github/workflows/create_source_tarballs/Dockerfile
+++ b/.github/workflows/create_source_tarballs/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /home/builder
 # || Environment ||
 # =================
 ENV SCRIPTS_DIR="/tmp/scripts"
-COPY environment $SCRIPTS_DIR/environment
+COPY .github/workflows/create_source_tarballs/environment $SCRIPTS_DIR/environment
 
 ENV COMPONENT=${COMPONENT}
 ENV VERSION=${VERSION}
@@ -27,11 +27,11 @@ ENV VERSION=${VERSION}
 # ============================
 # || Create Source Tarballs ||
 # ============================
-COPY step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
+COPY .github/workflows/create_source_tarballs/step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
 RUN $SCRIPTS_DIR/step-1_install_dependencies
 
-COPY step-2_download_source $SCRIPTS_DIR/step-2_download_source
+COPY .github/workflows/create_source_tarballs/step-2_download_source $SCRIPTS_DIR/step-2_download_source
 RUN $SCRIPTS_DIR/step-2_download_source
 
-COPY step-3_create_tarball $SCRIPTS_DIR/step-3_create_tarball
+COPY .github/workflows/create_source_tarballs/step-3_create_tarball $SCRIPTS_DIR/step-3_create_tarball
 RUN $SCRIPTS_DIR/step-3_create_tarball

--- a/.github/workflows/create_source_tarballs/build.sh
+++ b/.github/workflows/create_source_tarballs/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euox pipefail
+
+# Usage: Run from repo root with component and version
+#   .github/workflows/create_source_tarballs/build.sh <COMPONENT> <VERSION>
+#
+# Examples:
+#   .github/workflows/create_source_tarballs/build.sh musl 1.2.5
+#   .github/workflows/create_source_tarballs/build.sh gcc 15.2.0
+
+docker build \
+    -f .github/workflows/create_source_tarballs/Dockerfile \
+    --build-arg COMPONENT="${1}" \
+    --build-arg VERSION="${2}" \
+    -t create-source-tarballs \
+    .
+
+CONTAINER_ID=$(docker create create-source-tarballs)
+docker cp "${CONTAINER_ID}:/tmp/artifacts/." .
+docker rm "${CONTAINER_ID}"

--- a/.github/workflows/create_source_tarballs/step-2_download_source
+++ b/.github/workflows/create_source_tarballs/step-2_download_source
@@ -78,9 +78,18 @@ case "${COMPONENT}" in
         rm -rf "${SOURCE_DIR}/.git"
         ;;
 
+    musl)
+        # Download from official musl libc site
+        TARBALL="/tmp/musl-${VERSION}.tar.gz"
+        retry_with_backoff "${TARBALL}" \
+            wget -O "${TARBALL}" "https://musl.libc.org/releases/musl-${VERSION}.tar.gz"
+        tar xf "${TARBALL}" -C "${SOURCE_DIR}" --strip-components=1
+        rm "${TARBALL}"
+        ;;
+
     *)
         echo "ERROR: Unknown component '${COMPONENT}'"
-        echo "Valid components: binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc"
+        echo "Valid components: binutils, zlib, glibc, linux, gmp, mpfr, isl, mpc, gcc, musl"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

Implements Epic 2 of the musl bootstrap plan: Add musl to source tarballs.

This PR extends the `create_source_tarballs` workflow to support downloading and packaging musl libc source code.

## Changes

- **Workflow YAML**: Added `musl` to component dropdown options
- **Download script**: Added musl case that downloads from https://musl.libc.org/releases/
- **Dockerfile**: Fixed paths to use full `.github/workflows/create_source_tarballs/` prefix (enables building from repo root)
- **build.sh**: Created helper script for local testing (consistent with other workflows)

## Implementation Details

The musl download follows musl's official tarball distribution:
```bash
wget https://musl.libc.org/releases/musl-${VERSION}.tar.gz
```

This differs from other components that use git clones, because musl is officially distributed as release tarballs.

## Testing

Tested locally with Docker build:
```bash
.github/workflows/create_source_tarballs/build.sh musl 1.2.5
```

Successfully downloads musl 1.2.5 source and creates tarball.

## Success Criteria

- [x] Workflow accepts musl as component option
- [x] Downloads musl source from official musl.libc.org site
- [x] Creates compressed tarball (tar.xz format)
- [x] Can be tested locally with build.sh script
- [ ] Uploads to GitHub releases under `sources` tag (workflow execution required)

## Next Steps

After this PR is merged:
1. Run workflow to upload musl 1.2.5 source to releases:
   ```bash
   gh workflow run create_source_tarballs.yml -f component=musl -f version=1.2.5
   ```
2. Epic 3: Create musl libc build workflow

Part of the musl bootstrap plan.
Follows #129 (Epic 1: Enable musl-targeting binutils).