### PR TITLE
feat: add musl libc bootstrap build workflow

### DIFF
--- a/.github/workflows/build_musl.yml
+++ b/.github/workflows/build_musl.yml
@@ -1,0 +1,129 @@
+name: Build musl libc
+
+on:
+  workflow_dispatch:
+    inputs:
+      gcc_version:
+        description: 'GCC version to use for bootstrap'
+        required: true
+        default: '15.2.0'
+        type: string
+      musl_version:
+        description: 'musl version to build'
+        required: true
+        default: '1.2.5'
+        type: string
+      linux_version:
+        description: 'Linux kernel version for headers'
+        required: true
+        default: '6.18'
+        type: string
+      binutils_version:
+        description: 'Binutils version to download'
+        required: true
+        default: '2.45'
+        type: string
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_musl
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  GCC_VERSION: ${{ github.event.inputs.gcc_version }}
+  MUSL_VERSION: ${{ github.event.inputs.musl_version }}
+  LINUX_VERSION: ${{ github.event.inputs.linux_version }}
+  BINUTILS_VERSION: ${{ github.event.inputs.binutils_version }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.1
+
+      - name: Install dependencies
+        run: $SCRIPTS_DIR/step-01_install_dependencies
+
+      - name: Set up environment
+        run: $SCRIPTS_DIR/environment
+
+      - name: Download GMP source
+        run: $SCRIPTS_DIR/step-02.1_download_gmp_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download MPFR source
+        run: $SCRIPTS_DIR/step-02.2_download_mpfr_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download ISL source
+        run: $SCRIPTS_DIR/step-02.3_download_isl_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download MPC source
+        run: $SCRIPTS_DIR/step-02.4_download_mpc_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download GCC source
+        run: $SCRIPTS_DIR/step-02.5_download_gcc_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download Linux kernel source
+        run: $SCRIPTS_DIR/step-02.6_download_linux_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download musl source
+        run: $SCRIPTS_DIR/step-02.7_download_musl_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download pre-built binutils
+        run: $SCRIPTS_DIR/step-02.8_download_binutils
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux kernel headers
+        run: $SCRIPTS_DIR/step-03_install_linux_headers
+
+      - name: Build GMP
+        run: $SCRIPTS_DIR/step-04.1_build_gmp
+
+      - name: Build ISL
+        run: $SCRIPTS_DIR/step-04.2_build_isl
+
+      - name: Build MPFR
+        run: $SCRIPTS_DIR/step-04.3_build_mpfr
+
+      - name: Build MPC
+        run: $SCRIPTS_DIR/step-04.4_build_mpc
+
+      - name: Build core GCC (Stage 1)
+        run: $SCRIPTS_DIR/step-05_build_core_gcc
+
+      - name: Build musl libc (Stage 2)
+        run: $SCRIPTS_DIR/step-06_build_musl
+
+      - name: Package musl sysroot
+        run: $SCRIPTS_DIR/step-07_package_musl
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v3.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: $SCRIPTS_DIR/step-08_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_musl/Dockerfile
+++ b/.github/workflows/build_musl/Dockerfile
@@ -1,0 +1,85 @@
+FROM ubuntu:latest
+
+# =================
+# || Create User ||
+# =================
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y sudo
+
+RUN useradd -m -s /bin/bash builder && \
+    usermod -aG sudo builder
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER builder
+WORKDIR /home/builder
+
+# =================
+# || Environment ||
+# =================
+ENV SCRIPTS_DIR="/tmp/scripts"
+ENV UTILS_DIR="/tmp/scripts"
+COPY .github/workflows/build_musl/environment $SCRIPTS_DIR/environment
+COPY .github/workflows/utils/download_tarball $UTILS_DIR/download_tarball
+
+# ================
+# || Build musl ||
+# ================
+COPY .github/workflows/build_musl/step-01_install_dependencies ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-01_install_dependencies
+
+# Install newer GitHub CLI for attestation support (requires v2.47.0+)
+# Ubuntu package version is too old, so install from GitHub releases
+# We can assume the actions runner has a good enough version of gh so we only need it in the dockerfile
+ARG GH_VERSION="2.63.2"
+RUN wget "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf "gh_${GH_VERSION}_linux_amd64.tar.gz" && \
+    sudo install "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+
+ARG GH_TOKEN
+COPY .github/workflows/build_musl/step-02.1_download_gmp_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.1_download_gmp_source
+
+COPY .github/workflows/build_musl/step-02.2_download_mpfr_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.2_download_mpfr_source
+
+COPY .github/workflows/build_musl/step-02.3_download_isl_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.3_download_isl_source
+
+COPY .github/workflows/build_musl/step-02.4_download_mpc_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.4_download_mpc_source
+
+COPY .github/workflows/build_musl/step-02.5_download_gcc_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.5_download_gcc_source
+
+COPY .github/workflows/build_musl/step-02.6_download_linux_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.6_download_linux_source
+
+ARG MUSL_VERSION=1.2.5
+COPY .github/workflows/build_musl/step-02.7_download_musl_source ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.7_download_musl_source
+
+COPY .github/workflows/build_musl/step-02.8_download_binutils ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-02.8_download_binutils
+
+COPY .github/workflows/build_musl/step-03_install_linux_headers ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-03_install_linux_headers
+
+COPY .github/workflows/build_musl/step-04.1_build_gmp ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-04.1_build_gmp
+
+COPY .github/workflows/build_musl/step-04.2_build_isl ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-04.2_build_isl
+
+COPY .github/workflows/build_musl/step-04.3_build_mpfr ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-04.3_build_mpfr
+
+COPY .github/workflows/build_musl/step-04.4_build_mpc ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-04.4_build_mpc
+
+COPY .github/workflows/build_musl/step-05_build_core_gcc ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-05_build_core_gcc
+
+COPY .github/workflows/build_musl/step-06_build_musl ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-06_build_musl
+
+COPY .github/workflows/build_musl/step-07_package_musl ${SCRIPTS_DIR}/
+RUN ${SCRIPTS_DIR}/step-07_package_musl

--- a/.github/workflows/build_musl/build.sh
+++ b/.github/workflows/build_musl/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euox pipefail
+
+# Usage: Run from repo root with GitHub token
+#   .github/workflows/build_musl/build.sh <MUSL_VERSION> <GH_TOKEN>
+
+docker build \
+    -f .github/workflows/build_musl/Dockerfile \
+    --build-arg MUSL_VERSION=$1 \
+    --build-arg GH_TOKEN=$2 \
+    -t musl \
+    .
+
+CONTAINER_ID=$(docker create musl)
+docker cp "${CONTAINER_ID}:/tmp/artifacts/." .
+docker rm "${CONTAINER_ID}"

--- a/.github/workflows/build_musl/environment
+++ b/.github/workflows/build_musl/environment
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euox pipefail
+
+# ==============================
+# || Setup Source Directories ||
+# ==============================
+export GMP_SOURCE="/tmp/gmp-source"
+export MPFR_SOURCE="/tmp/mpfr-source"
+export ISL_SOURCE="/tmp/isl-source"
+export MPC_SOURCE="/tmp/mpc-source"
+export GCC_SOURCE="/tmp/gcc-source"
+export LINUX_SOURCE="/tmp/linux-source"
+export MUSL_SOURCE="/tmp/musl-source"
+
+mkdir -p ${GMP_SOURCE}
+mkdir -p ${MPFR_SOURCE}
+mkdir -p ${ISL_SOURCE}
+mkdir -p ${MPC_SOURCE}
+mkdir -p ${GCC_SOURCE}
+mkdir -p ${LINUX_SOURCE}
+mkdir -p ${MUSL_SOURCE}
+
+# ==============================
+# || Setup Output Directories ||
+# ==============================
+export BUILD_TOOLS="/tmp/buildtools"         # For core GCC + binutils + dependencies
+export SYSROOT_DIR="/tmp/sysroot"            # For musl + kernel headers
+export MUSL_ARTIFACTS="/tmp/musl-artifacts"  # For packaging
+export ARTIFACTS_DIR="/tmp/artifacts"        # For tarballs
+
+mkdir -p ${BUILD_TOOLS}
+mkdir -p ${SYSROOT_DIR}
+mkdir -p ${MUSL_ARTIFACTS}
+mkdir -p ${ARTIFACTS_DIR}
+
+# Ensures that ARTIFACTS_DIR is available to provenance attestation in
+# the github actions workflow.
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "${GITHUB_ENV}"
+fi

--- a/.github/workflows/build_musl/step-01_install_dependencies
+++ b/.github/workflows/build_musl/step-01_install_dependencies
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euox pipefail
+
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    wget \
+    curl \
+    texinfo \
+    bison \
+    flex \
+    gawk \
+    m4 \
+    python3 \
+    xz-utils \
+    rsync \
+    file \
+    autoconf \
+    automake \
+    libtool

--- a/.github/workflows/build_musl/step-02.1_download_gmp_source
+++ b/.github/workflows/build_musl/step-02.1_download_gmp_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "gmp-6.3.0.tar.xz" "${GMP_SOURCE}"

--- a/.github/workflows/build_musl/step-02.2_download_mpfr_source
+++ b/.github/workflows/build_musl/step-02.2_download_mpfr_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "mpfr-4.2.2.tar.xz" "${MPFR_SOURCE}"

--- a/.github/workflows/build_musl/step-02.3_download_isl_source
+++ b/.github/workflows/build_musl/step-02.3_download_isl_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "isl-0.27.tar.xz" "${ISL_SOURCE}"

--- a/.github/workflows/build_musl/step-02.4_download_mpc_source
+++ b/.github/workflows/build_musl/step-02.4_download_mpc_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "mpc-1.3.1.tar.xz" "${MPC_SOURCE}"

--- a/.github/workflows/build_musl/step-02.5_download_gcc_source
+++ b/.github/workflows/build_musl/step-02.5_download_gcc_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "gcc-15.2.0.tar.xz" "${GCC_SOURCE}"

--- a/.github/workflows/build_musl/step-02.6_download_linux_source
+++ b/.github/workflows/build_musl/step-02.6_download_linux_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "linux-6.18.tar.xz" "${LINUX_SOURCE}"

--- a/.github/workflows/build_musl/step-02.7_download_musl_source
+++ b/.github/workflows/build_musl/step-02.7_download_musl_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "musl-${MUSL_VERSION}.tar.xz" "${MUSL_SOURCE}"

--- a/.github/workflows/build_musl/step-02.8_download_binutils
+++ b/.github/workflows/build_musl/step-02.8_download_binutils
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+${UTILS_DIR}/download_tarball "x86_64-linux-x86_64-linux-musl-binutils-2.45-20251220.tar.xz" "${BUILD_TOOLS}"

--- a/.github/workflows/build_musl/step-03_install_linux_headers
+++ b/.github/workflows/build_musl/step-03_install_linux_headers
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+LINUX_BUILD_DIR="/tmp/build-kernel-headers"
+mkdir -p ${LINUX_BUILD_DIR}
+
+pushd "${LINUX_SOURCE}"
+
+make \
+    "HOSTCC=gcc" \
+    "O=${LINUX_BUILD_DIR}" \
+    "ARCH=x86" \
+    "INSTALL_HDR_PATH=${SYSROOT_DIR}/usr" \
+    "V=0" \
+    headers_install
+
+popd

--- a/.github/workflows/build_musl/step-04.1_build_gmp
+++ b/.github/workflows/build_musl/step-04.1_build_gmp
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${GMP_SOURCE}"
+
+##################################################################################
+# GMP Build Configuration                                                        #
+##################################################################################
+#                                                                                #
+# GMP (GNU Multiple Precision Arithmetic Library) provides arbitrary precision   #
+# arithmetic used by GCC for compile-time constant folding and optimization.     #
+# This library will be statically linked into GCC binaries.                      #
+#                                                                                #
+# COMPILER FLAGS                                                                 #
+# ============================================================================== #
+# * `-O3`: Aggressive optimization for GCC's compile-time performance            #
+# * `-pipe`: Use pipes instead of temp files (faster compilation)                #
+#                                                                                #
+# CONFIGURE FLAGS                                                                #
+# ============================================================================== #
+# * `--build=x86_64-pc-linux-gnu`: Build system triplet (where GMP is built)     #
+# * `--host=x86_64-pc-linux-gnu`: Host system triplet (where GMP will run)       #
+#   - See "Portability Requirements" section in README.md for why these are      #
+#     required to ensure the toolchain runs on any x86_64 Linux system           #
+#                                                                                #
+# * `--prefix="${BUILD_TOOLS}"`: Install location                                #
+#   - Headers: ${BUILD_TOOLS}/include/                                           #
+#   - Libraries: ${BUILD_TOOLS}/lib/                                             #
+#   - Makes GMP available for building MPFR, MPC, ISL, and GCC                   #
+#                                                                                #
+# * `--enable-fft`: Enable FFT multiplication for large numbers                  #
+#   - Faster multiplication for very large numbers                               #
+#   - Used by GCC for compile-time arithmetic optimizations                      #
+#   - Default is "yes" but we specify explicitly for clarity                     #
+#                                                                                #
+# * `--enable-cxx`: Build C++ interface (libgmpxx)                               #
+#   - Required dependency for ISL (Integer Set Library)                          #
+#   - ISL uses C++ bindings to GMP for exact integer arithmetic                  #
+#   - Default is "no" so we must enable explicitly                               #
+#   - Produces libgmpxx.a and gmpxx.h                                            #
+#                                                                                #
+# * `--disable-shared`: Don't build shared libraries                             #
+#   - GMP will be statically linked into GCC binaries                            #
+#                                                                                #
+# * `--enable-static`: Build static libraries for static linking into GCC        #
+#   - Combined with --disable-shared ensures static-only build                   #
+#                                                                                #
+##################################################################################
+
+env CFLAGS="-O3 -pipe" \
+    ./configure \
+        --build=x86_64-pc-linux-gnu \
+        --host=x86_64-pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --enable-fft \
+        --enable-cxx \
+        --disable-shared \
+        --enable-static
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_musl/step-04.2_build_isl
+++ b/.github/workflows/build_musl/step-04.2_build_isl
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${ISL_SOURCE}"
+
+##################################################################################
+# ISL Build Configuration                                                        #
+##################################################################################
+#                                                                                #
+# ISL (Integer Set Library) provides polyhedral compilation support for GCC's    #
+# Graphite framework, enabling advanced loop optimizations.                      #
+# This library will be statically linked into GCC binaries.                      #
+#                                                                                #
+# COMPILER FLAGS                                                                 #
+# ============================================================================== #
+# * `-O3`: Aggressive optimization for GCC's compile-time performance            #
+# * `-pipe`: Use pipes instead of temp files (faster compilation)                #
+# * `-I${BUILD_TOOLS}/include`: Find GMP headers                                 #
+#                                                                                #
+# LINKER FLAGS                                                                   #
+# ============================================================================== #
+# * `-L${BUILD_TOOLS}/lib`: Find GMP static libraries                            #
+#                                                                                #
+# CONFIGURE FLAGS                                                                #
+# ============================================================================== #
+# * `--build=x86_64-pc-linux-gnu`: Build system triplet (where ISL is built)     #
+# * `--host=x86_64-pc-linux-gnu`: Host system triplet (where ISL will run)       #
+#                                                                                #
+# * `--prefix="${BUILD_TOOLS}"`: Install location                                #
+#   - Headers: ${BUILD_TOOLS}/include/                                           #
+#   - Libraries: ${BUILD_TOOLS}/lib/                                             #
+#   - Makes ISL available for GCC build                                          #
+#                                                                                #
+# * `--with-gmp=system`: Use system-provided GMP (not bundled)                   #
+#   - "system" here means the GMP we built in step-05                            #
+#   - GMP is the default integer library for ISL                                 #
+#   - https://libisl.sourceforge.io/user.html                                    #
+#                                                                                #
+# * `--with-gmp-prefix="${BUILD_TOOLS}"`: Where to find GMP                      #
+#   - Looks for headers in ${BUILD_TOOLS}/include                                #
+#   - Looks for libraries in ${BUILD_TOOLS}/lib                                  #
+#                                                                                #
+# * `--enable-thread-safe`: Build thread-safe library                            #
+#   - Required for GCC's parallel compilation                                    #
+#                                                                                #
+# * `--disable-shared`: Don't build shared libraries                             #
+#   - ISL will be statically linked into GCC binaries                            #
+#                                                                                #
+# * `--enable-static`: Build static libraries for static linking into GCC        #
+#   - Combined with --disable-shared ensures static-only build                   #
+#                                                                                #
+# * `--with-clang=no`: Don't try to use Clang                                    #
+#   - We're using GCC, avoid autodetection issues                                #
+#   - ISL can optionally use Clang features                                      #
+#                                                                                #
+##################################################################################
+
+./autogen.sh
+
+env CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
+    CXXFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
+    LDFLAGS="-L${BUILD_TOOLS}/lib" \
+    ./configure \
+        --build=x86_64-pc-linux-gnu \
+        --host=x86_64-pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --with-gmp=system \
+        --with-gmp-prefix="${BUILD_TOOLS}" \
+        --enable-thread-safe \
+        --disable-shared \
+        --enable-static \
+        --with-clang=no
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_musl/step-04.3_build_mpfr
+++ b/.github/workflows/build_musl/step-04.3_build_mpfr
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${MPFR_SOURCE}"
+
+##################################################################################
+# MPFR Build Configuration                                                       #
+##################################################################################
+#                                                                                #
+# MPFR (Multiple Precision Floating-Point Reliable Library) provides arbitrary   #
+# precision floating-point arithmetic used by GCC for compile-time constant      #
+# folding and optimization. This library will be statically linked into GCC      #
+# binaries.                                                                      #
+#                                                                                #
+# COMPILER FLAGS                                                                 #
+# ============================================================================== #
+# * `-O3`: Aggressive optimization for GCC's compile-time performance            #
+# * `-pipe`: Use pipes instead of temp files (faster compilation)                #
+# * `-I${BUILD_TOOLS}/include`: Find GMP headers                                 #
+#                                                                                #
+# LINKER FLAGS                                                                   #
+# ============================================================================== #
+# * `-L${BUILD_TOOLS}/lib`: Find GMP static libraries                            #
+#                                                                                #
+# CONFIGURE FLAGS                                                                #
+# ============================================================================== #
+# * `--build=x86_64-pc-linux-gnu`: Build system triplet (where MPFR is built)    #
+# * `--host=x86_64-pc-linux-gnu`: Host system triplet (where MPFR will run)      #
+#                                                                                #
+# * `--prefix="${BUILD_TOOLS}"`: Install location                                #
+#   - Headers: ${BUILD_TOOLS}/include/                                           #
+#   - Libraries: ${BUILD_TOOLS}/lib/                                             #
+#   - Makes MPFR available for building MPC and GCC                              #
+#                                                                                #
+# * `--with-gmp="${BUILD_TOOLS}"`: Location of GMP installation                  #
+#   - Tells MPFR where to find GMP headers and libraries                         #
+#   - MPFR depends on GMP for exact integer arithmetic                           #
+#                                                                                #
+# * `--enable-thread-safe`: Build thread-safe library                            #
+#   - Uses compiler-level Thread-Local Storage (TLS)                             #
+#   - Makes default precision, flags, and rounding mode per-thread instead of    #
+#     global                                                                     #
+#   - Required for multithreaded GCC compilation                                 #
+#   - https://fossies.org/linux/mpfr/INSTALL                                     #
+#   - https://www.mpfr.org/mpfr-current/mpfr.html                                #
+#                                                                                #
+# * `--disable-shared`: Don't build shared libraries                             #
+#   - MPFR will be statically linked into GCC binaries                           #
+#                                                                                #
+# * `--enable-static`: Build static libraries for static linking into GCC        #
+#   - Combined with --disable-shared ensures static-only build                   #
+#                                                                                #
+##################################################################################
+
+# Generate the configure script and other build files using autotools
+# MPFR's Git repository doesn't include the configure script - it must be
+# generated from configure.ac using autotools (aclocal, autoconf, automake, etc.)
+./autogen.sh
+
+env CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
+    LDFLAGS="-L${BUILD_TOOLS}/lib" \
+    ./configure \
+        --build=x86_64-pc-linux-gnu \
+        --host=x86_64-pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --with-gmp="${BUILD_TOOLS}" \
+        --enable-thread-safe \
+        --disable-shared \
+        --enable-static
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_musl/step-04.4_build_mpc
+++ b/.github/workflows/build_musl/step-04.4_build_mpc
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${MPC_SOURCE}"
+
+##################################################################################
+# MPC Build Configuration                                                        #
+##################################################################################
+#                                                                                #
+# MPC (Multiple Precision Complex Library) provides arbitrary precision complex  #
+# number arithmetic used by GCC for compile-time constant folding and            #
+# optimization. This library will be statically linked into GCC binaries.        #
+#                                                                                #
+# COMPILER FLAGS                                                                 #
+# ============================================================================== #
+# * `-O3`: Aggressive optimization for GCC's compile-time performance            #
+# * `-pipe`: Use pipes instead of temp files (faster compilation)                #
+# * `-I${BUILD_TOOLS}/include`: Find GMP and MPFR headers                        #
+#                                                                                #
+# LINKER FLAGS                                                                   #
+# ============================================================================== #
+# * `-L${BUILD_TOOLS}/lib`: Find GMP and MPFR static libraries                   #
+#                                                                                #
+# CONFIGURE FLAGS                                                                #
+# ============================================================================== #
+# * `--build=x86_64-pc-linux-gnu`: Build system triplet (where MPC is built)     #
+# * `--host=x86_64-pc-linux-gnu`: Host system triplet (where MPC will run)       #
+#   - See "Portability Requirements" section in README.md for why these are      #
+#     required to ensure the toolchain runs on any x86_64 Linux system           #
+#                                                                                #
+# * `--prefix="${BUILD_TOOLS}"`: Install location                                #
+#   - Headers: ${BUILD_TOOLS}/include/                                           #
+#   - Libraries: ${BUILD_TOOLS}/lib/                                             #
+#   - Makes MPC available for GCC build                                          #
+#                                                                                #
+# * `--with-gmp="${BUILD_TOOLS}"`: Location of GMP installation                  #
+#   - Tells MPC where to find GMP headers and libraries                          #
+#   - MPC depends on GMP for arbitrary precision integer arithmetic              #
+#                                                                                #
+# * `--with-mpfr="${BUILD_TOOLS}"`: Location of MPFR installation                #
+#   - Tells MPC where to find MPFR headers and libraries                         #
+#   - MPC depends on MPFR for arbitrary precision floating-point arithmetic      #
+#                                                                                #
+# * `--disable-shared`: Don't build shared libraries                             #
+#   - MPC will be statically linked into GCC binaries                            #
+#                                                                                #
+# * `--enable-static`: Build static libraries for static linking into GCC        #
+#   - Combined with --disable-shared ensures static-only build                   #
+#                                                                                #
+##################################################################################
+
+# Generate the configure script and other build files using autotools
+# MPC's Git repository doesn't include the configure script - it must be
+# generated from configure.ac using autotools (aclocal, autoconf, automake, etc.)
+autoreconf -i
+
+env CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
+    CXXFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
+    LDFLAGS="-L${BUILD_TOOLS}/lib" \
+    ./configure \
+        --build=x86_64-pc-linux-gnu \
+        --host=x86_64-pc-linux-gnu \
+        --prefix="${BUILD_TOOLS}" \
+        --with-gmp="${BUILD_TOOLS}" \
+        --with-mpfr="${BUILD_TOOLS}" \
+        --disable-shared \
+        --enable-static
+
+make -j$(nproc) -l
+make install
+
+popd

--- a/.github/workflows/build_musl/step-05_build_core_gcc
+++ b/.github/workflows/build_musl/step-05_build_core_gcc
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+##################################################################################
+# Core GCC Build Configuration                                                   #
+##################################################################################
+#                                                                                #
+# This builds a minimal C-only GCC for bootstrapping musl libc.                 #
+# This compiler cannot link against musl (musl doesn't exist yet), but it can   #
+# compile musl's source code.                                                   #
+#                                                                                #
+# KEY BOOTSTRAP FLAGS                                                            #
+# ============================================================================== #
+#                                                                                #
+# * `--target=x86_64-linux-musl`: Target musl-based system                      #
+#   - Tells GCC to generate code for musl target                                #
+#                                                                                #
+# * `--with-newlib`: Pretend we're using newlib (embedded libc)                 #
+#   - Critical flag that tells GCC "no full C library exists yet"               #
+#   - Prevents GCC from expecting libc functions during libgcc build            #
+#   - Configures libgcc to work in freestanding environment                     #
+#                                                                                #
+# * `--enable-threads=no`: Disable threading support                            #
+#   - Threading requires libc functions (pthread_create, etc.)                  #
+#   - We don't have musl yet, so no threading                                   #
+#                                                                                #
+# * `--disable-shared`: Only build static libraries                             #
+#   - Shared libraries require dynamic linker from libc                         #
+#   - We don't have musl yet, so only static                                    #
+#                                                                                #
+# * `--enable-languages=c`: C language only                                     #
+#   - No C++ (libstdc++ requires full libc)                                     #
+#   - No other languages                                                        #
+#                                                                                #
+# * `--disable-libstdcxx`: Don't build C++ standard library                     #
+#   - Reinforces that we're not building C++ support                            #
+#                                                                                #
+# WHAT THIS COMPILER CAN DO                                                     #
+# ============================================================================== #
+# - Compile C source code to object files                                       #
+# - Use Linux kernel syscalls directly (headers are installed)                  #
+# - Build musl libc from source                                                 #
+#                                                                                #
+# WHAT THIS COMPILER CANNOT DO                                                  #
+# ============================================================================== #
+# - Compile C++ code (no g++, no libstdc++)                                     #
+# - Link against musl (musl doesn't exist yet!)                                 #
+# - Create multithreaded programs                                               #
+# - Create dynamically linked binaries                                          #
+#                                                                                #
+##################################################################################
+
+CORE_GCC_BUILD_DIR="/tmp/core-gcc-build"
+mkdir -p "${CORE_GCC_BUILD_DIR}"
+
+pushd "${CORE_GCC_BUILD_DIR}"
+
+env CFLAGS="-O2 -I${BUILD_TOOLS}/include" \
+    CFLAGS_FOR_BUILD="-O2 -I${BUILD_TOOLS}/include" \
+    CXXFLAGS="-O2 -I${BUILD_TOOLS}/include" \
+    CXXFLAGS_FOR_BUILD="-O2 -I${BUILD_TOOLS}/include" \
+    LDFLAGS="-L${BUILD_TOOLS}/lib" \
+    CFLAGS_FOR_TARGET="-O2" \
+    CXXFLAGS_FOR_TARGET="-O2" \
+    LDFLAGS_FOR_TARGET="" \
+    ${GCC_SOURCE}/configure \
+        --build=x86_64-pc-linux-gnu \
+        --host=x86_64-pc-linux-gnu \
+        --target=x86_64-linux-musl \
+        --prefix=${BUILD_TOOLS} \
+        --with-sysroot=${SYSROOT_DIR} \
+        --with-local-prefix=${SYSROOT_DIR} \
+        \
+        --with-newlib \
+        --enable-threads=no \
+        --disable-shared \
+        --disable-libstdcxx \
+        \
+        --enable-languages=c \
+        \
+        --disable-libgomp \
+        --disable-libssp \
+        --disable-libquadmath \
+        --disable-libquadmath-support \
+        --disable-libsanitizer \
+        \
+        --with-gmp=${BUILD_TOOLS} \
+        --with-mpfr=${BUILD_TOOLS} \
+        --with-mpc=${BUILD_TOOLS} \
+        --with-isl=${BUILD_TOOLS} \
+        \
+        --disable-multilib \
+        --disable-nls \
+        --enable-lto
+
+# Build only what we need for bootstrapping
+make -j$(nproc) all-gcc all-target-libgcc
+
+# Install only gcc and libgcc
+make install-gcc install-target-libgcc
+
+popd
+

--- a/.github/workflows/build_musl/step-06_build_musl
+++ b/.github/workflows/build_musl/step-06_build_musl
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+##################################################################################
+# musl libc Build Configuration                                                  #
+##################################################################################
+#                                                                                #
+# This builds musl libc using the core GCC from Stage 1.                         #
+#                                                                                #
+# BUILD ENVIRONMENT                                                              #
+# ============================================================================== #
+#                                                                                #
+# * `CC`: Path to the C compiler (core GCC built in step-05)                    #
+# * `AR`, `RANLIB`: Binutils tools for creating archives                        #
+#                                                                                #
+# CONFIGURE OPTIONS                                                              #
+# ============================================================================== #
+#                                                                                #
+# * `--prefix=/usr`: Install to /usr (within DESTDIR)                            #
+#   - Standard location for C library                                            #
+#                                                                                #
+# * `--syslibdir=/usr/lib`: Library directory                                    #
+#   - Where libc.so and other libraries will be installed                        #
+#                                                                                #
+# * `--enable-shared`: Build shared libraries                                    #
+#   - Creates libc.so for dynamic linking                                        #
+#                                                                                #
+# * `--enable-static`: Build static libraries                                    #
+#   - Creates libc.a for static linking                                          #
+#                                                                                #
+# * `--enable-optimize=auto`: Let musl choose optimization level                 #
+#   - musl has sensible defaults for optimization                                #
+#                                                                                #
+##################################################################################
+
+MUSL_BUILD_DIR="/tmp/musl-build"
+mkdir -p "${MUSL_BUILD_DIR}"
+
+pushd "${MUSL_BUILD_DIR}"
+
+env CC="${BUILD_TOOLS}/bin/x86_64-linux-musl-gcc" \
+    AR="${BUILD_TOOLS}/bin/x86_64-linux-musl-ar" \
+    RANLIB="${BUILD_TOOLS}/bin/x86_64-linux-musl-ranlib" \
+    ${MUSL_SOURCE}/configure \
+        --prefix=/usr \
+        --syslibdir=/usr/lib \
+        --enable-shared \
+        --enable-static \
+        --enable-optimize=auto
+
+make -j$(nproc)
+
+make DESTDIR="${MUSL_ARTIFACTS}" install
+
+popd

--- a/.github/workflows/build_musl/step-07_package_musl
+++ b/.github/workflows/build_musl/step-07_package_musl
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd "${MUSL_ARTIFACTS}"
+tar -cJf "${ARTIFACTS_DIR}/x86_64-linux-musl-musl-${MUSL_VERSION}.tar.xz" .
+popd
+

--- a/.github/workflows/build_musl/step-08_upload_release
+++ b/.github/workflows/build_musl/step-08_upload_release
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+# Upload to the binaries release (same as all other build workflows)
+gh release upload binaries \
+    ${ARTIFACTS_DIR}/*.tar.xz \
+    --clobber


### PR DESCRIPTION
Implements Epic 3 from the musl bootstrap plan.

## Summary

Adds a new GitHub Actions workflow to build musl libc using a two-stage bootstrap process:
- **Stage 1**: Build minimal C-only GCC (core GCC)
- **Stage 2**: Build musl libc using core GCC

## What's included

- `.github/workflows/build_musl.yml` - Main workflow file
- `.github/workflows/build_musl/` - All build scripts:
  - Environment setup and dependency installation
  - Source downloads (GMP, MPFR, ISL, MPC, GCC, Linux, musl, binutils)
  - Linux kernel header installation
  - GCC dependency builds
  - Core GCC build (Stage 1)
  - musl libc build (Stage 2)
  - Packaging and release upload
- Dockerfile for local testing

## Dependencies

- Requires pre-built musl-targeting binutils from Epic 1
- Requires musl source tarballs from Epic 2
- Uses Linux 6.18 kernel headers

## Output

Produces `x86_64-linux-musl-musl-{VERSION}.tar.xz` containing:
- musl libc libraries (libc.a, libc.so)
- C library headers
- Dynamic linker (ld-musl-x86_64.so.1)
- Linux kernel headers

Uploaded to the `binaries` release with provenance attestation.

## Notes

This workflow is temporary and will be removed once the first full musl GCC compiler is successfully bootstrapped.