### PR TITLE
fix: isolate buildifier_prebuilt dependency from public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run buildifier
         run: |
-          ./bazel run :buildifier.check
+          ./bazel run //private:buildifier.check
 
   commitlint:
     runs-on: ubuntu-latest

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,30 +1,6 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
-
 # this allows for the convenience toolchain to be registered by users with fun naming. Ex:
 # register_toolchains("@toolchains_cc")
 alias(
     name = "toolchains_cc",
     actual = "@toolchains_cc_default_toolchain",
-)
-
-# ./bazel run :buildifier.check
-buildifier(
-    name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-    ],
-    lint_mode = "warn",
-    mode = "check",
-    visibility = ["//visibility:private"],
-)
-
-# ./bazel run :buildifier.fix
-buildifier(
-    name = "buildifier.fix",
-    exclude_patterns = [
-        "./.git/*",
-    ],
-    lint_mode = "warn",
-    mode = "fix",
-    visibility = ["//visibility:private"],
 )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,10 @@ Use the `./bazel` wrapper script instead of `bazel`
 ## Linting
 ```bash
 # Check Bazel file formatting
-./bazel run :buildifier.check
+./bazel run //private:buildifier.check
 
 # Auto-fix Bazel file formatting
-./bazel run :buildifier.fix
+./bazel run //private:buildifier.fix
 ```
 
 

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+# ./bazel run //private:buildifier.check
+buildifier(
+    name = "buildifier.check",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "warn",
+    mode = "check",
+    visibility = ["//visibility:private"],
+)
+
+# ./bazel run //private:buildifier.fix
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "warn",
+    mode = "fix",
+    visibility = ["//visibility:private"],
+)


### PR DESCRIPTION
Problem
================================================================================

External repositories depending on toolchains_cc fail with repository resolution errors because buildifier_prebuilt is not accessible to them.

Context
================================================================================

What errors occur?
--------------------------------------------------------------------------------

When external projects add toolchains_cc as a dependency, Bazel fails during toolchain resolution with:

  Unable to find package for @@[unknown repo 'buildifier_prebuilt'
  requested from @@toolchains_cc+]//:rules.bzl: The repository
  '@@[unknown repo 'buildifier_prebuilt' requested from @@toolchains_cc+]'
  could not be resolved: No repository visible as '@buildifier_prebuilt'
  from repository '@@toolchains_cc+'.

What is wrong with the current state of the code?
--------------------------------------------------------------------------------

The root BUILD.bazel file loads buildifier_prebuilt and defines buildifier targets. This makes buildifier_prebuilt part of the public API surface, causing Bazel to require it when external repositories depend on toolchains_cc.

Buildifier is a development tool used only for linting Bazel files in this repository's CI. External users should not need it or even know about it.

Solution
================================================================================

Move buildifier_prebuilt load statement and all buildifier targets from BUILD.bazel to private/BUILD.bazel. Update all references:

- CI workflow: :buildifier.check → //private:buildifier.check
- Documentation: Update CLAUDE.md linting commands to use new paths

The root BUILD.bazel now contains only the public API (toolchains_cc alias).

Rationale
================================================================================

Why move to private/BUILD.bazel instead of keeping in root? --------------------------------------------------------------------------------

Any load statement or target in the root BUILD.bazel is considered part of the public API. Moving to private/ clearly signals these are internal development tools not meant for external consumption.

Why move the load statement, not just the targets? --------------------------------------------------------------------------------

Even if the buildifier targets have private visibility, the load statement itself causes Bazel to try resolving @buildifier_prebuilt when analyzing the root package. The load statement must move with the targets.

Why not mark buildifier_prebuilt as a dev dependency? --------------------------------------------------------------------------------

Bazel's module system doesn't have a concept of dev dependencies that are invisible to dependents. The only way to hide a dependency is to not reference it from packages that external users might load.