### PR TITLE
fix: resolve SIGPIPE error in update-bazelisk workflow

### DIFF
--- a/.github/workflows/update-bazelisk/update-bazelisk.sh
+++ b/.github/workflows/update-bazelisk/update-bazelisk.sh
@@ -25,7 +25,9 @@ fi
 
 echo "Changes detected - proceeding with commit and PR creation"
 
-NEW_VERSION=$(./tools/bazelisk-linux-amd64 version | head -n1 | sed 's/Bazelisk version: //')
+# Capture full output first, then extract version to avoid SIGPIPE with `set -o pipefail`
+BAZELISK_OUTPUT=$(./tools/bazelisk-linux-amd64 version)
+NEW_VERSION=$(echo "$BAZELISK_OUTPUT" | awk '/^Bazelisk version:/ {print $3; exit}')
 echo "New Bazelisk version: $NEW_VERSION"
 
 git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- Fixes exit code 141 (SIGPIPE) in the update-bazelisk workflow
- Captures full `bazelisk version` output before extracting the version to avoid pipe breakage

## Test plan

- [ ] Manually trigger the update-bazelisk workflow to verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)