### PR TITLE
chore: download glibc build dependencies from attested releases

### DIFF
--- a/.github/workflows/build_gcc/step-3.2_install_binutils
+++ b/.github/workflows/build_gcc/step-3.2_install_binutils
@@ -2,8 +2,4 @@
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
 
-if [[ "${BOOTSTRAP}" == "true" ]]; then
-    exit 0
-fi
-
 "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-binutils-2.45-" "${BUILD_TOOLS}"

--- a/.github/workflows/build_glibc/Dockerfile
+++ b/.github/workflows/build_glibc/Dockerfile
@@ -37,9 +37,6 @@ RUN $SCRIPTS_DIR/step-2.2_download_linux_source
 COPY .github/workflows/build_glibc/step-3.1_install_linux_headers $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-3.1_install_linux_headers
 
-COPY x86_64-linux-x86_64-bootstrap-linux-gnu-binutils-2.45-20260213.tar.xz /tmp/
-COPY x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-bootstrap-15.2.0-20260213.tar.xz /tmp/
-
 COPY .github/workflows/build_glibc/step-3.2_install_gcc $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-3.2_install_gcc
 

--- a/.github/workflows/build_glibc/step-3.2_install_gcc
+++ b/.github/workflows/build_glibc/step-3.2_install_gcc
@@ -2,5 +2,5 @@
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
 
-tar -xf /tmp/x86_64-linux-x86_64-bootstrap-linux-gnu-binutils-2.45-20260213.tar.xz -C "${SYSROOT_DIR}"
-tar -xf /tmp/x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-bootstrap-15.2.0-20260213.tar.xz -C "${SYSROOT_DIR}"
+"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-binutils-2.45-" "${SYSROOT_DIR}"
+"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-bootstrap-15.2.0-" "${SYSROOT_DIR}"


### PR DESCRIPTION
Problem
================================================================================

The glibc build requires bootstrap binutils and bootstrap GCC tarballs as build dependencies, but these are currently copied from local files in the Docker build context. This blocks CI, which needs to pull attested artifacts from GitHub releases.

Context
================================================================================

What functionality is blocked?
--------------------------------------------------------------------------------

The glibc Dockerfile uses COPY to bring in local tarball files with hardcoded date-suffixed filenames. CI runners don't have these local files available, so the glibc build cannot run in CI without manual intervention.

What errors occur?
--------------------------------------------------------------------------------

The previous commit updated the GCC build to download dependencies from GitHub releases but missed the glibc build, which still had hardcoded local COPY lines. Additionally, the GCC build's step-3.2_install_binutils incorrectly skipped binutils download on bootstrap builds, but bootstrap GCC needs the bootstrap binutils (it expects x86_64-bootstrap-linux-gnu-as, etc.).

Solution
================================================================================

- Replace hardcoded tar commands in the glibc build's step-3.2_install_gcc with download_tarball calls, using the same pattern-based resolution as the GCC build
- Remove the two local COPY lines from the glibc Dockerfile
- Remove the bootstrap skip in the GCC build's step-3.2_install_binutils, since bootstrap GCC also needs bootstrap binutils

Rationale
================================================================================

Why not keep local COPY for glibc?
--------------------------------------------------------------------------------

All build dependencies should come from attested GitHub release artifacts. This ensures CI can run the builds without local files, and every dependency is verified against its build provenance attestation before use.