### PR TITLE
feat: add target selection to GCC build workflow

### DIFF
--- a/.github/workflows/build_gcc.yml
+++ b/.github/workflows/build_gcc.yml
@@ -8,7 +8,16 @@ on:
         required: true
         default: '["15.2.0"]'
         type: string
-
+      target:
+        description: 'Target triplet'
+        required: true
+        default: 'x86_64-linux-gnu'
+        type: choice
+        options:
+          - x86_64-linux-gnu
+          - x86_64-bootstrap-linux-gnu
+          - x86_64-linux-musl
+          - x86_64-bootstrap-linux-musl
 permissions:
   # Required for uploading GitHub releases
   contents: write
@@ -19,6 +28,7 @@ permissions:
 env:
   SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_gcc
   UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  TARGET: ${{ github.event.inputs.target }}
 
 jobs:
   build:

--- a/.github/workflows/build_gcc/Dockerfile
+++ b/.github/workflows/build_gcc/Dockerfile
@@ -45,7 +45,6 @@ COPY .github/workflows/build_gcc/step-2.5_download_gcc_source $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-2.5_download_gcc_source
 
 ARG TARGET=x86_64-linux-musl
-ARG BOOTSTRAP=true
 COPY .github/workflows/build_gcc/step-3.1_install_linux_headers $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-3.1_install_linux_headers
 

--- a/.github/workflows/build_gcc/build.sh
+++ b/.github/workflows/build_gcc/build.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 set -euox pipefail
 
-# Usage: Run from repo root with GCC version and GitHub token
-#   .github/workflows/build_gcc/build.sh <GCC_VERSION> <TARGET> <BOOTSTRAP> <GH_TOKEN>
-#   .github/workflows/build_gcc/build.sh 15.2.0 x86_64-linux-gnu false <GH_TOKEN>
-#   .github/workflows/build_gcc/build.sh 15.2.0 x86_64-bootstrap-linux-gnu true <GH_TOKEN>
+# Usage: Run from repo root with GCC version, target, and GitHub token
+#   .github/workflows/build_gcc/build.sh <GCC_VERSION> <TARGET> <GH_TOKEN>
+#   .github/workflows/build_gcc/build.sh 15.2.0 x86_64-linux-gnu <GH_TOKEN>
+#   .github/workflows/build_gcc/build.sh 15.2.0 x86_64-bootstrap-linux-gnu <GH_TOKEN>
 
 docker build \
     -f .github/workflows/build_gcc/Dockerfile \
     --build-arg GCC_VERSION="${1}" \
     --build-arg TARGET="${2}" \
-    --build-arg BOOTSTRAP="${3}" \
-    --build-arg GH_TOKEN="${4}" \
+    --build-arg GH_TOKEN="${3}" \
     -t gcc \
     .
 

--- a/.github/workflows/build_gcc/environment
+++ b/.github/workflows/build_gcc/environment
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euox pipefail
 
+# Derive BOOTSTRAP from the target triple's vendor field.
+# Targets with "bootstrap" in the vendor (e.g., x86_64-bootstrap-linux-gnu)
+# produce a minimal C-only compiler for building libc.
+if [[ "${TARGET}" == *-bootstrap-* ]]; then
+    export BOOTSTRAP="true"
+else
+    export BOOTSTRAP="false"
+fi
+
 # ==============================
 # || Setup Source Directories ||
 # ==============================


### PR DESCRIPTION
Problem
================================================================================

The GCC build workflow had no target input, so bootstrap builds could not be kicked off from the GitHub UI.

Context
================================================================================

What functionality is missing?
--------------------------------------------------------------------------------

The workflow only accepted a GCC version input. To build a bootstrap compiler (e.g., x86_64-bootstrap-linux-gnu), there was no way to specify the target triple from the GitHub Actions UI. The BOOTSTRAP flag was a separate Docker build arg that had to be manually kept in sync with the target triple.

Solution
================================================================================

Add a target choice input to the workflow with all four supported triples (x86_64-linux-gnu, x86_64-bootstrap-linux-gnu, x86_64-linux-musl, x86_64-bootstrap-linux-musl) and derive the BOOTSTRAP flag from the target triple's vendor field in the environment script.

This removes the separate BOOTSTRAP input from the workflow, the BOOTSTRAP ARG from the Dockerfile, and the BOOTSTRAP parameter from build.sh.

Rationale
================================================================================

Why derive BOOTSTRAP from the target triple?
--------------------------------------------------------------------------------

Whether a build is a bootstrap build is an inherent property of the target triple — the "bootstrap" vendor field already encodes it. Having a separate flag is redundant and a source of mismatch bugs (e.g., selecting a bootstrap target but setting BOOTSTRAP=false).

Why derive in the environment script?
--------------------------------------------------------------------------------

The environment script is sourced by every build step in both the Dockerfile and the GitHub Actions workflow. Deriving BOOTSTRAP there ensures a single source of truth regardless of how the build is invoked.