### PR TITLE
chore: update GCC workflow to use new install step scripts

### DIFF
--- a/.github/workflows/build_gcc.yml
+++ b/.github/workflows/build_gcc.yml
@@ -84,8 +84,18 @@ jobs:
       - name: Install Linux kernel headers
         run: $SCRIPTS_DIR/step-3.1_install_linux_headers
 
-      - name: Install glibc
-        run: $SCRIPTS_DIR/step-3.2_install_glibc
+      - name: Install binutils
+        run: $SCRIPTS_DIR/step-3.2_install_binutils
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install toolchain libc
+        run: $SCRIPTS_DIR/step-3.3_install_libc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install bootstrapping gcc
+        run: $SCRIPTS_DIR/step-3.4_install_gcc
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Problem
================================================================================

The GCC workflow still referenced the old step-3.2_install_glibc script, which was replaced by the new split install scripts (step-3.2_install_binutils, step-3.3_install_libc, step-3.4_install_gcc) that download attested artifacts from GitHub releases.

Solution
================================================================================

Replace the single "Install glibc" step with the three new install steps (binutils, libc, gcc), each with GITHUB_TOKEN for downloading release artifacts.