### PR TITLE
fix: align glibc workflow with Dockerfile build steps

### DIFF
--- a/.github/workflows/build_glibc.yml
+++ b/.github/workflows/build_glibc.yml
@@ -51,7 +51,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Install Linux kernel headers
-        run: ${{ env.SCRIPTS_DIR }}/step-3_install_linux_headers
+        run: ${{ env.SCRIPTS_DIR }}/step-3.1_install_linux_headers
+
+      - name: Install bootstrap gcc and binutils
+        run: ${{ env.SCRIPTS_DIR }}/step-3.2_install_gcc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build glibc
         run: ${{ env.SCRIPTS_DIR }}/step-4_build_glibc


### PR DESCRIPTION
Problem
================================================================================

The glibc GitHub Actions workflow was missing the bootstrap gcc/binutils install step and had an incorrect script name for installing Linux kernel headers, so CI builds would fail.

Context
================================================================================

What errors occur?
--------------------------------------------------------------------------------

The workflow referenced step-3_install_linux_headers, but the actual script is step-3.1_install_linux_headers. The step-3.2_install_gcc script (which downloads bootstrap binutils and gcc from attested releases) was missing entirely, so the glibc build would fail when it tried to invoke x86_64-bootstrap-linux-gnu-gcc.

Solution
================================================================================

- Rename step-3_install_linux_headers to step-3.1_install_linux_headers
- Add the missing step-3.2_install_gcc step with GITHUB_TOKEN for downloading attested release artifacts