### PR TITLE
chore: lower glibc build dependency to 2.26 and merge gcc lib packages

### DIFF
--- a/.github/workflows/build_gcc/Dockerfile
+++ b/.github/workflows/build_gcc/Dockerfile
@@ -18,6 +18,7 @@ COPY .github/workflows/utils/download_tarball $UTILS_DIR/
 # ===============
 # || Build GCC ||
 # ===============
+ARG TARGET=x86_64-linux-musl
 COPY .github/workflows/build_gcc/step-01_install_dependencies $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-01_install_dependencies
 
@@ -44,7 +45,6 @@ ARG GCC_VERSION=15.2.0
 COPY .github/workflows/build_gcc/step-2.5_download_gcc_source $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-2.5_download_gcc_source
 
-ARG TARGET=x86_64-linux-musl
 COPY .github/workflows/build_gcc/step-3.1_install_linux_headers $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-3.1_install_linux_headers
 

--- a/.github/workflows/build_gcc/step-3.3_install_libc
+++ b/.github/workflows/build_gcc/step-3.3_install_libc
@@ -9,7 +9,8 @@ if [[ "${BOOTSTRAP}" == "true" ]]; then
 fi
 
 if [[ "${TARGET}" == *-gnu ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-glibc-2.28-" "${BUILD_TOOLS}"
+    # we build against an old glibc to make sure the libgcc and libstdc++ encode a minimal glibc version
+    "${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-glibc-2.26-" "${BUILD_TOOLS}"
 elif [[ "${TARGET}" == *-musl ]]; then
     "${UTILS_DIR}/download_tarball" "x86_64-linux-musl-musl-1.2.5-" "${BUILD_TOOLS}"
 fi

--- a/.github/workflows/build_gcc/step-3.4_install_gcc
+++ b/.github/workflows/build_gcc/step-3.4_install_gcc
@@ -9,8 +9,8 @@ if [[ "${BOOTSTRAP}" == "true" ]]; then
 fi
 
 if [[ "${TARGET}" == *-gnu ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-bootstrap-${GCC_VERSION}-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-${GCC_VERSION}-" "${BUILD_TOOLS}"
 elif [[ "${TARGET}" == *-musl ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-musl-gcc-bootstrap-${GCC_VERSION}-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-musl-gcc-${GCC_VERSION}-" "${BUILD_TOOLS}"
 fi
 

--- a/.github/workflows/build_gcc/step-5_package_toolchain
+++ b/.github/workflows/build_gcc/step-5_package_toolchain
@@ -14,47 +14,24 @@ if [[ "${BOOTSTRAP}" == "true" ]]; then
     # ===========================
     # || Package bootstrap gcc ||
     # ===========================
-    tar cJf "${ARTIFACTS_DIR}/x86_64-linux-${TARGET}-gcc-bootstrap-${GCC_FULL_VERSION}-${DATE}.tar.xz" .
+    tar cJf "${ARTIFACTS_DIR}/x86_64-linux-${TARGET}-gcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" .
 else
     # =======================
-    # || Package libstdc++ ||
+    # || Package gcc libs  ||
     # =======================
-    cp -r share share-libstdcxx
+    cp -r share share-lib
 
-    LIBSTDCXX_FILES=()
-    LIBSTDCXX_FILES+=(share-libstdcxx)
-    LIBSTDCXX_FILES+=(${TARGET}/include/c++/)
-    LIBSTDCXX_FILES+=(${TARGET}/lib64/libitm*)
-    LIBSTDCXX_FILES+=(${TARGET}/lib64/libstdc++*)
-    LIBSTDCXX_FILES+=(${TARGET}/lib64/libsupc++*)
-
-    tar cJf "${ARTIFACTS_DIR}/${TARGET}-libstdcxx-${GCC_FULL_VERSION}-${DATE}.tar.xz" \
-        "${LIBSTDCXX_FILES[@]}"
-
-    rm -rf "${LIBSTDCXX_FILES[@]}"
-
-    # =======================================
-    # || Package gcc compiler runtime libs ||
-    # =======================================
-    cp -r share share-libgcc
-
-    LIBGCC_FILES=()
-    LIBGCC_FILES+=(share-libgcc)
-    LIBGCC_FILES+=(lib/gcc)
-    LIBGCC_FILES+=(${TARGET}/lib64/libgcc*)
-    LIBGCC_FILES+=(${TARGET}/lib64/libatomic*)
-
-    tar cJf "${ARTIFACTS_DIR}/${TARGET}-libgcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" \
-        "${LIBGCC_FILES[@]}"
-
-    rm -rf "${LIBGCC_FILES[@]}"
+    tar cJf "${ARTIFACTS_DIR}/${TARGET}-gcc-lib-${GCC_FULL_VERSION}-${DATE}.tar.xz" \
+        ${TARGET}/include/c++/ \
+        ${TARGET}/lib64/ \
+        lib/ \
+        share-lib/
 
     # =================
     # || Package gcc ||
     # =================
     tar cJf "${ARTIFACTS_DIR}/x86_64-linux-${TARGET}-gcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" \
         bin/ \
-        lib/ \
         libexec/ \
         share/
 fi


### PR DESCRIPTION
Problem
================================================================================

The GCC toolchain's libgcc and libstdc++ encode a minimum glibc version based on the glibc they are built against. Building against glibc 2.28 produces binaries that cannot run on Amazon Linux 2, which ships glibc 2.26.

Context
================================================================================

What functionality is missing?
--------------------------------------------------------------------------------

Amazon Linux 2 uses glibc 2.26. Any binary linked against our libgcc/libstdc++ built with glibc 2.28 will fail to run on AL2 due to glibc version symbol requirements. This is a proactive change to ensure compatibility before users hit runtime failures.

What is wrong with the current packaging?
--------------------------------------------------------------------------------

libstdc++ and libgcc were packaged as separate tarballs, but libstdc++ has a hard runtime dependency on libgcc — they cannot be used independently. For example, you cannot replace libgcc with compiler-rt while still using libstdc++. Separate packages added complexity without providing real flexibility.

Solution
================================================================================

- Lower the glibc build dependency from 2.28 to 2.26 in step-3.3_install_libc so that libgcc and libstdc++ encode glibc 2.26 as their minimum version
- Merge the separate libstdc++ and libgcc packages into a single gcc-lib package containing all GCC runtime libraries, headers, and support files
- Move the gcc compiler package's lib/ directory into the gcc-lib package since it contains runtime support files (lib/gcc/)
- Move the TARGET ARG earlier in the Dockerfile to fix a bug where it was not available to steps that now depend on it via the environment script

Rationale
================================================================================

Why glibc 2.26 specifically?
--------------------------------------------------------------------------------

Amazon Linux 2 is the oldest supported OS that still uses glibc 2.26. Other mainstream distributions have moved to newer glibc versions, making AL2 the binding constraint.

Why merge libstdc++ and libgcc into one package?
--------------------------------------------------------------------------------

libstdc++ depends on libgcc at runtime, so they were never truly independent packages. Merging them reflects reality and simplifies the build pipeline without losing any flexibility.