### PR TITLE
chore: bump gcc version.

### DIFF
--- a/.github/workflows/build_gcc/step-3.3_install_libc
+++ b/.github/workflows/build_gcc/step-3.3_install_libc
@@ -10,7 +10,7 @@ fi
 
 if [[ "${TARGET}" == *-gnu ]]; then
     # we build against an old glibc to make sure the libgcc and libstdc++ encode a minimal glibc version
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-glibc-2.26-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-glibc-2.28-" "${BUILD_TOOLS}"
 elif [[ "${TARGET}" == *-musl ]]; then
     "${UTILS_DIR}/download_tarball" "x86_64-linux-musl-musl-1.2.5-" "${BUILD_TOOLS}"
 fi


### PR DESCRIPTION
We cant support glibc 2.26 with clang builds. No point in keeping AL2 support. Just going to support 2.28+