### PR TITLE
fix: patch ld to resolve absolute paths in glibc linker scripts under…

### DIFF
--- a/.github/workflows/build_binutils/Dockerfile
+++ b/.github/workflows/build_binutils/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:latest
 # ===========
 ENV SCRIPTS_DIR="/tmp/scripts"
 ENV UTILS_DIR="/tmp/scripts"
+ENV PATCHES_DIR="/tmp/patches"
 
 COPY .github/workflows/utils/initialize_user $UTILS_DIR/initialize_user
 RUN $UTILS_DIR/initialize_user
@@ -31,6 +32,10 @@ RUN $SCRIPTS_DIR/step-2.1_download_zlib_source
 ARG BINUTILS_VERSION=2.43
 COPY .github/workflows/build_binutils/step-2.2_download_binutils_source $SCRIPTS_DIR/step-2.2_download_binutils_source
 RUN $SCRIPTS_DIR/step-2.2_download_binutils_source
+
+COPY .github/workflows/build_binutils/patches $PATCHES_DIR/build_binutils/patches
+COPY .github/workflows/build_binutils/step-2.3_patch_binutils_source $SCRIPTS_DIR/step-2.3_patch_binutils_source
+RUN $SCRIPTS_DIR/step-2.3_patch_binutils_source
 
 COPY .github/workflows/build_binutils/step-3.1_build_zlib $SCRIPTS_DIR/step-3.1_build_zlib
 RUN $SCRIPTS_DIR/step-3.1_build_zlib

--- a/.github/workflows/build_binutils/patches/0001-ld-always-try-sysroot-prefix-for-absolute-paths.patch
+++ b/.github/workflows/build_binutils/patches/0001-ld-always-try-sysroot-prefix-for-absolute-paths.patch
@@ -1,0 +1,64 @@
+From 471d1d6d49821cfadfc232d2e44eaaa76f6e4186 Mon Sep 17 00:00:00 2001
+From: Sven Rebhan <odinshorse@googlemail.com>
+Date: Mon, 8 Aug 2022 20:46:29 +1200
+Subject: [PATCH] ld: always try sysroot prefix for absolute paths
+
+Always try to prepend the sysroot prefix to absolute filenames first.
+
+When ld opens a linker script (e.g. libm.so containing GROUP directives
+with absolute paths like /lib64/libm.so.6), it uses is_sysrooted_pathname()
+to decide whether those absolute paths should be resolved relative to the
+sysroot. is_sysrooted_pathname() canonicalizes both paths via lrealpath()
+(which calls realpath()) and checks if the script path starts with the
+sysroot path. This fails when symlinks cause the two paths to resolve to
+different base directories, as happens in Bazel's sandbox where directories
+are real but leaf files are symlinks to the external repo cache.
+
+This patch changes ldfile_open_file_search() to always try prepending
+the sysroot to absolute paths, regardless of is_sysrooted_pathname().
+If the sysroot-prepended path exists, it's used. Otherwise, the original
+absolute path is tried as a fallback.
+
+http://bugs.gentoo.org/275666
+http://sourceware.org/bugzilla/show_bug.cgi?id=10340
+
+Signed-off-by: Sven Rebhan <odinshorse@googlemail.com>
+---
+ ld/ldfile.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/ld/ldfile.c b/ld/ldfile.c
+index 75fd360d..6d208be3 100644
+--- a/ld/ldfile.c
++++ b/ld/ldfile.c
+@@ -556,18 +556,25 @@ ldfile_open_file_search (const char *arch,
+      directory first.  */
+   if (!entry->flags.maybe_archive)
+     {
+-      if (entry->flags.sysrooted && IS_ABSOLUTE_PATH (entry->filename))
++      /* For absolute pathnames, try to always open the file in the
++	 sysroot first. If this fails, try to open the file at the
++	 given location.  */
++      entry->flags.sysrooted = is_sysrooted_pathname (entry->filename);
++      if (!entry->flags.sysrooted && IS_ABSOLUTE_PATH (entry->filename)
++	  && ld_sysroot)
+ 	{
+ 	  char *name = concat (ld_sysroot, entry->filename,
+ 			       (const char *) NULL);
+ 	  if (ldfile_try_open_bfd (name, entry))
+ 	    {
+ 	      entry->filename = name;
++	      entry->flags.sysrooted = true;
+ 	      return true;
+ 	    }
+ 	  free (name);
+ 	}
+-      else if (ldfile_try_open_bfd (entry->filename, entry))
++
++      if (ldfile_try_open_bfd (entry->filename, entry))
+ 	return true;
+
+       if (IS_ABSOLUTE_PATH (entry->filename))
+--
+2.50.1
+

--- a/.github/workflows/build_binutils/step-2.3_patch_binutils_source
+++ b/.github/workflows/build_binutils/step-2.3_patch_binutils_source
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+cd ${BINUTILS_SOURCE}
+
+# Bazel's sandbox uses symlinks that break ld's realpath()-based sysroot
+# detection, causing it to ignore --sysroot when resolving absolute paths
+# inside glibc linker scripts (e.g. libm.so's GROUP directive).
+# See more: docs/lore/binutils/ld_sysroot_absolute_paths_in_linker_scripts.md
+patch -p1 < "${PATCHES_DIR}/build_binutils/patches/0001-ld-always-try-sysroot-prefix-for-absolute-paths.patch"

--- a/docs/lore/binutils/ld_sysroot_absolute_paths_in_linker_scripts.md
+++ b/docs/lore/binutils/ld_sysroot_absolute_paths_in_linker_scripts.md
@@ -1,0 +1,77 @@
+# ld Fails to Resolve Absolute Paths in glibc Linker Scripts Under Bazel Sandbox
+
+## Problem Summary
+
+Linking a simple C++ program fails because `ld` cannot find libraries referenced by absolute path inside glibc's linker scripts. The sysroot is correctly configured, but `ld` tries to open `/lib64/libm.so.6` on the host filesystem instead of `<sysroot>/lib64/libm.so.6`.
+
+## Symptoms
+
+When building `//tests/hello_world:hello` with a cross-toolchain configured with `--sysroot`:
+
+```
+ld: cannot find /lib64/libm.so.6: No such file or directory
+ld: cannot find /usr/lib64/libmvec_nonshared.a: No such file or directory
+ld: cannot find /lib64/libmvec.so.1: No such file or directory
+```
+
+### Diagnostic Clues
+
+Verbose linker output (`-v`) shows that `ld` finds `libm.so` inside the sysroot correctly:
+
+```
+attempt to open external/+cc_toolchains+toolchains_cc_default_toolchain_bins/usr/lib/../lib64/libm.so succeeded
+opened script file external/+cc_toolchains+toolchains_cc_default_toolchain_bins/usr/lib/../lib64/libm.so
+```
+
+But when it parses the linker script inside that file and encounters the absolute paths from its `GROUP` directive, it tries them literally on the host:
+
+```
+attempt to open /lib64/libm.so.6 failed
+attempt to open /usr/lib64/libmvec_nonshared.a failed
+attempt to open /lib64/libmvec.so.1 failed
+```
+
+## Background: glibc Libraries Are Linker Scripts
+
+On glibc-based systems, several "shared libraries" are not ELF binaries — they are short **linker scripts** (ld scripts). glibc installs these because the actual implementation is split across multiple objects. For example, `libm.so` is typically a text file:
+
+```
+/* GNU ld script */
+GROUP ( /lib64/libm.so.6 AS_NEEDED ( /lib64/libmvec_nonshared.a /lib64/libmvec.so.1 ) )
+```
+
+This tells `ld` to link against the real shared object (`libm.so.6`) plus additional objects. Other common glibc ld scripts include `libc.so` and `libpthread.so`.
+
+The paths inside these scripts are **absolute**, reflecting where glibc was installed on the original system. This works for native compilation because `/lib64/libm.so.6` exists on the host. For cross-compilation or sandboxed builds with `--sysroot`, the linker must prepend the sysroot to those absolute paths.
+
+## Root Cause
+
+When `ld` is invoked with `--sysroot=<path>`, it uses `is_sysrooted_pathname()` to decide whether absolute paths from linker scripts should be resolved relative to the sysroot. This function **canonicalizes both paths** via `lrealpath()` (which calls `realpath()`) and checks whether the script's resolved path starts with the sysroot's resolved path.
+
+This breaks in Bazel's sandbox. Bazel constructs sandbox directories where the directory structure is real, but leaf files are **symlinks** pointing into the external repository cache. After `realpath()`, the script's canonical location resolves to somewhere in the cache (e.g., `/home/user/.cache/bazel/...`), which does not start with the sysroot prefix. So `is_sysrooted_pathname()` returns false, and `ld` treats the absolute paths literally instead of prepending the sysroot.
+
+### Why This Specifically Affects Bazel
+
+In a typical cross-compilation setup, the sysroot is a real directory tree and `realpath()` preserves the prefix relationship. Bazel's sandboxing breaks this assumption by creating a directory tree of symlinks, so `realpath()` resolves out of the sandbox entirely.
+
+## Upstream Bug History
+
+This is a known class of bug with a long upstream history:
+
+- **Gentoo [#275666](https://bugs.gentoo.org/275666)** (2009): Cross-compilation with sysroot failed because `ld` searched the host filesystem before the sysroot when linker scripts contained absolute paths. Fixed in binutils 2.19.51.0.12.
+
+- **Sourceware [#10340](https://sourceware.org/bugzilla/show_bug.cgi?id=10340)** (2009): Same core issue reported upstream. Alan Modra committed a fix in 2012 refactoring `ldfile.c`, `ldlang.c`, and `ldlex.l` to better track sysroot prefixes during linker script processing.
+
+The upstream fix improved the situation but still relies on `is_sysrooted_pathname()` with `realpath()`-based canonicalization, so it continues to fail when symlinks break the prefix check.
+
+## The Fix
+
+We apply a patch to binutils: `.github/workflows/build_binutils/patches/0001-ld-always-try-sysroot-prefix-for-absolute-paths.patch`
+
+The patch changes `ldfile_open_file_search()` in `ld/ldfile.c`:
+
+**Before (upstream):** If `is_sysrooted_pathname()` says the file is within the sysroot AND the path is absolute, prepend the sysroot. Otherwise, try the path as-is. These two branches are mutually exclusive (`if`/`else if`).
+
+**After (patched):** For any absolute path when a sysroot is configured, **always try** prepending the sysroot first regardless of what `is_sysrooted_pathname()` returns. If the sysroot-prefixed path exists, use it. If not, fall back to the original absolute path. The `else if` becomes a plain `if`, making the two attempts independent.
+
+This is a conservative change: it only adds a best-effort sysroot lookup before the existing fallback path. When the sysroot-prefixed file doesn't exist, behavior is unchanged.


### PR DESCRIPTION
… sysroot

Problem
================================================================================

Linking C/C++ programs fails when glibc linker scripts (e.g. libm.so) contain absolute paths like /lib64/libm.so.6, because ld tries to open them on the host filesystem instead of prepending the --sysroot prefix.

Context
================================================================================

What errors occur?
--------------------------------------------------------------------------------

The linker finds libm.so inside the sysroot correctly, but libm.so is a glibc linker script containing GROUP directives with absolute paths. When ld parses these paths, it fails to prepend the sysroot:

    ld: cannot find /lib64/libm.so.6: No such file or directory
    ld: cannot find /usr/lib64/libmvec_nonshared.a: No such file or directory
    ld: cannot find /lib64/libmvec.so.1: No such file or directory

Why does ld fail to use the sysroot?
--------------------------------------------------------------------------------

ld uses is_sysrooted_pathname() to decide whether absolute paths should be resolved relative to the sysroot. This function canonicalizes both paths via realpath() and checks if the script's resolved path starts with the sysroot's resolved path. In Bazel's sandbox, leaf files are symlinks into the external repo cache, so realpath() resolves the script to a path outside the sysroot, and is_sysrooted_pathname() returns false.

This is a well-known upstream issue:
- https://bugs.gentoo.org/275666
- https://sourceware.org/bugzilla/show_bug.cgi?id=10340

Solution
================================================================================

Patch ld's ldfile_open_file_search() to always try prepending the sysroot to absolute paths first, regardless of what is_sysrooted_pathname() returns. If the sysroot-prefixed path exists, use it; otherwise fall back to the original path.

The binutils build now includes a patching step (step-2.3) that applies this patch before compilation.

Rationale
================================================================================

Why patch binutils rather than work around it in the toolchain config? --------------------------------------------------------------------------------

The bug is in ld's path resolution logic. No amount of sysroot configuration can fix it because the failure occurs after ld has already found and opened the linker script inside the sysroot — it's the secondary lookups for the script's GROUP members that go wrong. The fix must be in ld itself.

Why not upstream the patch?
--------------------------------------------------------------------------------

Upstream fixed a related issue in 2012 but the fix still relies on realpath()-based canonicalization, which fundamentally doesn't work with symlink-based sandboxes. This patch takes a simpler approach (always try sysroot first) that is conservative — it only adds a best-effort lookup and doesn't change behavior when the sysroot-prefixed file doesn't exist.