### PR TITLE
fix: add binutils patching step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_binutils.yml
+++ b/.github/workflows/build_binutils.yml
@@ -29,6 +29,7 @@ permissions:
 env:
   SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_binutils
   UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  PATCHES_DIR: ${{ github.workspace }}/.github/workflows/build_binutils/patches
   TARGET: ${{ github.event.inputs.target }}
 
 jobs:
@@ -61,6 +62,9 @@ jobs:
         run: $SCRIPTS_DIR/step-2.2_download_binutils_source
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Patch binutils source
+        run: $SCRIPTS_DIR/step-2.3_patch_binutils_source
 
       - name: Build zlib
         run: $SCRIPTS_DIR/step-3.1_build_zlib

--- a/.github/workflows/build_binutils/Dockerfile
+++ b/.github/workflows/build_binutils/Dockerfile
@@ -33,7 +33,7 @@ ARG BINUTILS_VERSION=2.43
 COPY .github/workflows/build_binutils/step-2.2_download_binutils_source $SCRIPTS_DIR/step-2.2_download_binutils_source
 RUN $SCRIPTS_DIR/step-2.2_download_binutils_source
 
-COPY .github/workflows/build_binutils/patches $PATCHES_DIR/build_binutils/patches
+COPY .github/workflows/build_binutils/patches $PATCHES_DIR
 COPY .github/workflows/build_binutils/step-2.3_patch_binutils_source $SCRIPTS_DIR/step-2.3_patch_binutils_source
 RUN $SCRIPTS_DIR/step-2.3_patch_binutils_source
 

--- a/.github/workflows/build_binutils/step-2.3_patch_binutils_source
+++ b/.github/workflows/build_binutils/step-2.3_patch_binutils_source
@@ -8,4 +8,4 @@ cd ${BINUTILS_SOURCE}
 # detection, causing it to ignore --sysroot when resolving absolute paths
 # inside glibc linker scripts (e.g. libm.so's GROUP directive).
 # See more: docs/lore/binutils/ld_sysroot_absolute_paths_in_linker_scripts.md
-patch -p1 < "${PATCHES_DIR}/build_binutils/patches/0001-ld-always-try-sysroot-prefix-for-absolute-paths.patch"
+patch -p1 < "${PATCHES_DIR}/0001-ld-always-try-sysroot-prefix-for-absolute-paths.patch"


### PR DESCRIPTION
Problem
================================================================================

The binutils ld sysroot patch was added to the Dockerfile build path but not to the GitHub Actions workflow, so CI builds still produce unpatched binutils.

Context
================================================================================

The previous commit added a patch step (step-2.3) and wired it into the Dockerfile, but the GitHub Actions workflow YAML was not updated to include the new step. Additionally, PATCHES_DIR used unnecessary intermediate subdirectories that made the path in the patch script harder to follow.

Solution
================================================================================

Add the "Patch binutils source" step to build_binutils.yml between downloading and building. Define PATCHES_DIR in the workflow env pointing directly to the patches directory, and simplify the Dockerfile COPY and patch script to use PATCHES_DIR without intermediate subdirectories.

Rationale
================================================================================

Why point PATCHES_DIR directly to the patches directory? --------------------------------------------------------------------------------

The previous layout had PATCHES_DIR="/tmp/patches" with patches copied to "$PATCHES_DIR/build_binutils/patches/", requiring the script to reference "${PATCHES_DIR}/build_binutils/patches/0001-...". Pointing PATCHES_DIR directly at the patches directory eliminates the redundant path segments and makes the script clearer.