### PR TITLE
feat: support toolchain configuration via MODULE.bazel tag attributes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,20 +193,22 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "toolchains_cc_dev": {
             "repoRuleId": "@@//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "toolchains_cc_dev"
+              "toolchain_name": "toolchains_cc_dev",
+              "config_overrides": {}
             }
           },
           "toolchains_cc_dev_bins": {
             "repoRuleId": "@@//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "toolchains_cc_dev"
+              "toolchain_name": "toolchains_cc_dev",
+              "config_overrides": {}
             }
           }
         }

--- a/examples/boost/MODULE.bazel.lock
+++ b/examples/boost/MODULE.bazel.lock
@@ -335,7 +335,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "t07dFfXroD/Px6unuqd0UIInaJh0Ed03/8uqe2zWhq0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -344,13 +344,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/curl/MODULE.bazel.lock
+++ b/examples/curl/MODULE.bazel.lock
@@ -227,7 +227,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "ytOVRzGgux6+Z+puB7pVw5IBB5VkOHhdx8hQvfCdrNQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -236,13 +236,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/fmt/MODULE.bazel.lock
+++ b/examples/fmt/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "Ogym/dCmE+yG3VjrEigpE5oYAo3HhD1gn3BPgweOWyg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -218,13 +218,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/googletest/MODULE.bazel.lock
+++ b/examples/googletest/MODULE.bazel.lock
@@ -280,7 +280,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "zF9BFQevLFjrq1Y9IIpx6f93/ZXqI7e2NkgYy5deUHs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -289,13 +289,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/grpc/MODULE.bazel.lock
+++ b/examples/grpc/MODULE.bazel.lock
@@ -491,7 +491,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "WxcHEIZnvJ2r2cz5siu2ypOOeLBsfmwcOut2YTNjdRs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -500,13 +500,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/libarchive/MODULE.bazel.lock
+++ b/examples/libarchive/MODULE.bazel.lock
@@ -220,7 +220,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "R86nS74LzgLi08NXWDNo+3iaLNYgMqGPzcdDsDn0bo4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -229,13 +229,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/libuv/MODULE.bazel.lock
+++ b/examples/libuv/MODULE.bazel.lock
@@ -208,7 +208,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "me3fgFonULuSv0lTy5/yk7ZgVtf20+DB7pADs2/mnJw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -217,13 +217,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/nlohmann_json/MODULE.bazel.lock
+++ b/examples/nlohmann_json/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "62/ziX0ezmh6xXvBBjyO/cLoXHFabHTF7Qk3IC6JNhI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -218,13 +218,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/protobuf/MODULE.bazel.lock
+++ b/examples/protobuf/MODULE.bazel.lock
@@ -288,7 +288,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "6ptHlcwHnIvOhaqa6gf388ytOHWRRqj8ZbvzVG0c+Ag=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -297,13 +297,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/sqlite/MODULE.bazel.lock
+++ b/examples/sqlite/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "hmLP2+eWOtQrYKPXKM2vUUap6waUis9xTl4GTYjHe5I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -218,13 +218,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/zlib/MODULE.bazel.lock
+++ b/examples/zlib/MODULE.bazel.lock
@@ -206,7 +206,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "KLh+0S9/jJzkEYXFDdXEVdFfBDFttBOGRsxrdxZmJ1s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -215,13 +215,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/examples/zstd/MODULE.bazel.lock
+++ b/examples/zstd/MODULE.bazel.lock
@@ -208,7 +208,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "8vahj4k5t3qLcGFrljirdHiWktYGo4IN/AmA33vWyso=",
+        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
         "usagesDigest": "NRFDpWlXnA3yL2SDjG9Iaxpylu88xhp3HdOgPna5/pA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -217,13 +217,15 @@
           "my_toolchain": {
             "repoRuleId": "@@toolchains_cc+//private:eager_declare_toolchain.bzl%eager_declare_toolchain",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           },
           "my_toolchain_bins": {
             "repoRuleId": "@@toolchains_cc+//private:lazy_download_bins.bzl%lazy_download_bins",
             "attributes": {
-              "toolchain_name": "my_toolchain"
+              "toolchain_name": "my_toolchain",
+              "config_overrides": {}
             }
           }
         },

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -12,18 +12,28 @@ load("//private:lazy_download_bins.bzl", "lazy_download_bins")
 # toolchain and another to download the toolchain binaries. The first is eagerly fetched when the toolchain is
 # registered, and the second is fetched only when the toolchain is actually used to compile C/C++ code. The module
 # extension must be used here because a repo rule isn't allowed to invoke another repo rule.
+_CONFIG_KEYS = ["target", "libc_version", "binutils_version", "compiler", "compiler_version", "linux_headers_version"]
+
 def _cc_toolchains(module_ctx):
     for mod in module_ctx.modules:
         for declared_toolchain in mod.tags.declare:
             toolchain_name = declared_toolchain.name
 
+            config_overrides = {}
+            for key in _CONFIG_KEYS:
+                val = getattr(declared_toolchain, key)
+                if val:
+                    config_overrides[key] = val
+
             eager_declare_toolchain(
                 name = declared_toolchain.name,
                 toolchain_name = toolchain_name,
+                config_overrides = config_overrides,
             )
             lazy_download_bins(
                 name = declared_toolchain.name + "_bins",
                 toolchain_name = toolchain_name,
+                config_overrides = config_overrides,
             )
 
 cc_toolchains = module_extension(
@@ -34,6 +44,24 @@ cc_toolchains = module_extension(
                 "name": attr.string(
                     mandatory = True,
                     doc = "The name of the toolchain, used for registration.",
+                ),
+                "target": attr.string(
+                    doc = "Target triple (e.g. x86_64-linux-gnu, x86_64-linux-musl). Overridden by --repo_env.",
+                ),
+                "libc_version": attr.string(
+                    doc = "Libc version (e.g. 2.28). Overridden by --repo_env.",
+                ),
+                "binutils_version": attr.string(
+                    doc = "Binutils version (e.g. 2.45). Overridden by --repo_env.",
+                ),
+                "compiler": attr.string(
+                    doc = "Compiler type (e.g. gcc). Overridden by --repo_env.",
+                ),
+                "compiler_version": attr.string(
+                    doc = "Compiler version (e.g. 15.2.0). Overridden by --repo_env.",
+                ),
+                "linux_headers_version": attr.string(
+                    doc = "Linux kernel headers version (e.g. 6.18). Overridden by --repo_env.",
                 ),
             },
         ),

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -2,33 +2,40 @@
 
 visibility("//private/...")
 
-# Why are environment variables used to configure toolchains_cc?
-# toolchains_cc should allow users to test their build with a wide range of toolchain configurations. For example,
-# an open source library author may want to ensure their library builds in CI with both gcc and clang, both glibc
-# and musl, and both libstdc++ and libc++ using a configuration matrix. To support this, the configuration
-# options must be provided to the repo rules via the bazel cli. Due to phases, providing them via bazel_skylib
-# string_flag(...) is not an option. This leaves us using --repo_env to set specific environment prefixed by the
-# toolchain name to disambiguate the configurations for multiple registered toolchains.
+# Configuration priority (highest to lowest):
+# 1. --repo_env flags (CLI / .bazelrc) — for CI matrix builds
+# 2. MODULE.bazel tag attributes (via config_overrides) — for project defaults
+# 3. Hard-coded defaults below — fallback
+#
+# --repo_env is essential for CI configuration matrices (e.g. testing gcc vs clang, glibc vs musl).
+# Due to Bazel phases, bazel_skylib string_flag(...) is not an option for this.
+# See: https://bazel.build/extending/repo#when_is_the_implementation_function_executed
 
-def _get_config(rctx, var_name, default):
+def _get_config(rctx, var_name, default, config_overrides):
+    # --repo_env takes highest priority
     var = "{}_{}".format(rctx.attr.toolchain_name, var_name)
     value = rctx.getenv(var)
-    if value == None:
-        return default
-    return value
+    if value != None:
+        return value
+
+    # MODULE.bazel tag attributes take medium priority
+    if var_name in config_overrides:
+        return config_overrides[var_name]
+
+    return default
 
 def _validate_config(config):
-    extended_triple = "{target}:{libc_version}:{compiler}:{compiler_version}".format(
-        target = config["target"],
-        libc_version = config["libc_version"],
-        compiler = config["compiler"],
-        compiler_version = config["compiler_version"],
-    )
-    if extended_triple not in SUPPORT_MATRIX:
-        fail("Configuration {extended_triple} is unsupported.".format(extended_triple = extended_triple))
+    for key, supported in SUPPORTED_VERSIONS.items():
+        value = config[key]
+        if value not in supported:
+            fail("Unsupported {key}={value}. Supported values: {supported}".format(
+                key = key,
+                value = value,
+                supported = ", ".join(sorted(supported.keys())),
+            ))
 
-def get_config_from_env_vars(rctx):
-    """Populates the configuration dictionary from the toolchain environment variables.
+def get_config(rctx):
+    """Populates the configuration dictionary from MODULE.bazel tag attributes and environment variables.
 
     Args:
       rctx: The repository context.
@@ -36,13 +43,14 @@ def get_config_from_env_vars(rctx):
     Returns:
         The configuration dictionary.
     """
+    config_overrides = rctx.attr.config_overrides
     config = {
-        "target": _get_config(rctx, "target", "x86_64-linux-gnu"),
-        "libc_version": _get_config(rctx, "libc_version", "2.28"),
-        "binutils_version": _get_config(rctx, "libc_version", "2.45"),
-        "compiler": _get_config(rctx, "compiler", "gcc"),
-        "compiler_version": _get_config(rctx, "compiler_version", "15.2.0"),
-        "linux_headers_version": _get_config(rctx, "linux_headers_version", "6.18"),
+        "target": _get_config(rctx, "target", "x86_64-linux-gnu", config_overrides),
+        "libc_version": _get_config(rctx, "libc_version", "2.28", config_overrides),
+        "binutils_version": _get_config(rctx, "binutils_version", "2.45", config_overrides),
+        "compiler": _get_config(rctx, "compiler", "gcc", config_overrides),
+        "compiler_version": _get_config(rctx, "compiler_version", "15.2.0", config_overrides),
+        "linux_headers_version": _get_config(rctx, "linux_headers_version", "6.18", config_overrides),
     }
 
     _validate_config(config)
@@ -73,42 +81,26 @@ common --repo_env={name}_libc_version={libc_version}
         compiler_version = config["compiler_version"],
     ))
 
-SUPPORT_MATRIX = {
-    ## GCC 14.3.0
-    # glibc
-    "x86_64-linux-gnu:2.28:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.29:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.30:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.31:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.32:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.33:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.34:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.35:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.36:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.37:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.38:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.39:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.40:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.41:gcc:14.3.0": True,
-    "x86_64-linux-gnu:2.42:gcc:14.3.0": True,
-
-    ## GCC 15.2.0
-    # glibc
-    "x86_64-linux-gnu:2.28:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.29:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.30:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.31:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.32:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.33:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.34:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.35:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.36:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.37:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.38:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.39:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.40:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.41:gcc:15.2.0": True,
-    "x86_64-linux-gnu:2.42:gcc:15.2.0": True,
-    # musl
-    "x86_64-linux-musl:1.2.5:gcc:15.2.0": True,
+# Each component is validated independently since downloads are decoupled.
+# To add a new supported version, add it here and in the corresponding
+# private/downloads/*.bzl file (RELEASE_TO_DATE + TARBALL_TO_SHA256).
+SUPPORTED_VERSIONS = {
+    "target": {
+        "x86_64-linux-gnu": True,
+    },
+    "libc_version": {
+        "2.28": True,
+    },
+    "compiler": {
+        "gcc": True,
+    },
+    "compiler_version": {
+        "15.2.0": True,
+    },
+    "binutils_version": {
+        "2.45": True,
+    },
+    "linux_headers_version": {
+        "6.18": True,
+    },
 }

--- a/private/declare_tools.bzl
+++ b/private/declare_tools.bzl
@@ -1,7 +1,6 @@
 """Macro for declaring the tools inside the lazy_download_bins repo rule."""
 
 load("@bazel_skylib//rules/directory:directory.bzl", "directory")
-load("@bazel_skylib//rules/directory:subdirectory.bzl", "subdirectory")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 

--- a/private/eager_declare_toolchain.bzl
+++ b/private/eager_declare_toolchain.bzl
@@ -1,9 +1,9 @@
 """Repo rule for eagerly declaring the C/C++ toolchain for use with register_toolchain(...)."""
 
-load(":config.bzl", "get_config_from_env_vars")
+load(":config.bzl", "get_config")
 
 def _eager_declare_toolchain(rctx):
-    config = get_config_from_env_vars(rctx)
+    config = get_config(rctx)
 
     rctx.file(
         "BUILD",
@@ -30,6 +30,9 @@ eager_declare_toolchain = repository_rule(
         "toolchain_name": attr.string(
             mandatory = True,
             doc = "The name of the toolchain, used for registration.",
+        ),
+        "config_overrides": attr.string_dict(
+            default = {},
         ),
     },
 )

--- a/private/lazy_download_bins.bzl
+++ b/private/lazy_download_bins.bzl
@@ -1,10 +1,10 @@
 """Repo rule for lazily downloading the C/C++ toolchain binaries when first used."""
 
 load("//private/downloads:all.bzl", "download_all")
-load(":config.bzl", "get_config_from_env_vars", "repro_dump")
+load(":config.bzl", "get_config", "repro_dump")
 
 def _lazy_download_bins(rctx):
-    config = get_config_from_env_vars(rctx)
+    config = get_config(rctx)
     repro_dump(rctx, config)
     download_all(rctx, config)
 
@@ -33,6 +33,9 @@ lazy_download_bins = repository_rule(
         "toolchain_name": attr.string(
             mandatory = True,
             doc = "The name of the toolchain, used for registration.",
+        ),
+        "config_overrides": attr.string_dict(
+            default = {},
         ),
     },
 )


### PR DESCRIPTION
Problem
================================================================================

Users must use --repo_env flags to configure toolchain settings (target, compiler version, libc version, etc.), which is atypical for Bazel. Users expect to declare configuration in MODULE.bazel, with CLI flags as an override mechanism rather than the only mechanism.

Context
================================================================================

What is atypical about the current configuration approach? --------------------------------------------------------------------------------

Bazel users normally declare toolchain configuration in MODULE.bazel. The current approach requires --repo_env flags for every build, which is unfamiliar and error-prone. The declare tag class only accepts a name attribute with no way to specify defaults for the toolchain configuration.

What other issues exist in the current configuration code? --------------------------------------------------------------------------------

The SUPPORT_MATRIX validates combinatorial entries (target:libc:compiler:version) but downloads are decoupled per-component, so validation should be per-component. The matrix also lists configurations (gcc 14.3.0, glibc 2.29-2.42, musl 1.2.5) that have no published tarballs. Additionally, the binutils_version config reads from the wrong environment variable (libc_version instead of binutils_version).

Solution
================================================================================

Add optional configuration attributes to the declare tag class in extensions.bzl so users can set defaults directly in MODULE.bazel. Configuration follows a three-tier priority: --repo_env flags override MODULE.bazel tag attributes, which override hard-coded defaults.

Changes:
- Add 6 optional config attrs to the declare tag class (target, libc_version, binutils_version, compiler, compiler_version, linux_headers_version)
- Thread config_overrides through repo rules to config.bzl
- Replace combinatorial SUPPORT_MATRIX with per-component SUPPORTED_VERSIONS that only lists versions with published tarballs
- Fix binutils_version reading from wrong env var

Rationale
================================================================================

Why preserve --repo_env as the highest priority override? --------------------------------------------------------------------------------

Open source library authors need CLI-level control to test builds against a range of toolchain configurations in CI matrices (e.g. gcc vs clang, glibc vs musl). This is less relevant for organizations targeting a single toolchain, but the override mechanism must exist for the CI matrix use case.

Why switch from combinatorial SUPPORT_MATRIX to per-component validation? --------------------------------------------------------------------------------

Downloads are already decoupled per-component (gcc.bzl, glibc.bzl, binutils.bzl, linux_headers.bzl). Validating each component independently matches this architecture and eliminates the combinatorial explosion of entries. It also prevents listing configurations that appear valid but have no tarballs.