### PR TITLE
chore: update gcc 15.2.0 x86_64-linux-gnu release metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Runbooks are detaild procedures for use in a specific context.
 - **BEFORE creating any commit, YOU MUST read**: [docs/runbooks/commit-message-guidelines.md](docs/runbooks/commit-message-guidelines.md)
 - **BEFORE adding new toolchain configurations, YOU MUST read**: [docs/runbooks/add-toolchain-configuration.md](docs/runbooks/add-toolchain-configuration.md)
 - **BEFORE creating or modifying GitHub Actions workflows, YOU MUST read**: [docs/runbooks/github-actions-workflows.md](docs/runbooks/github-actions-workflows.md)
+- **BEFORE updating release dates or SHA256 hashes for rebuilt toolchain binaries, YOU MUST read**: [docs/runbooks/update-binary-release-metadata.md](docs/runbooks/update-binary-release-metadata.md)
 
 ## Bazel
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/docs/runbooks/update-binary-release-metadata.md
+++ b/docs/runbooks/update-binary-release-metadata.md
@@ -1,0 +1,151 @@
+# Updating Binary Release Metadata
+
+This runbook describes the procedure for updating `RELEASE_TO_DATE` and `TARBALL_TO_SHA256` entries in the download files after a toolchain component has been rebuilt.
+
+## When to Use
+
+Use this runbook when a toolchain component (GCC, glibc, binutils, Linux headers, etc.) has been rebuilt due to changes in the build process and the new artifacts have been uploaded to the `binaries` GitHub release.
+
+## Overview
+
+Each download file in [private/downloads/](../../private/downloads/) contains two dictionaries that tie a logical release name to a dated tarball with a verified hash:
+
+- **`RELEASE_TO_DATE`**: Maps a release name (e.g., `x86_64-linux-x86_64-linux-gnu-gcc-15.2.0`) to a date string (e.g., `20260218`). The date is embedded in tarball filenames to distinguish rebuilds.
+- **`TARBALL_TO_SHA256`**: Maps a full tarball filename (which includes the date) to its SHA256 hash. Used by Bazel's `download_and_extract` to verify integrity.
+
+## Prerequisites
+
+- [ ] The rebuilt artifacts have been uploaded to the [`binaries` GitHub release](https://github.com/reutermj/toolchains_cc/releases/tag/binaries)
+- [ ] You know which component was rebuilt and which target/version is affected
+
+## Step-by-step Procedure
+
+### 1. Identify the affected download file
+
+Each component has its own file in [private/downloads/](../../private/downloads/):
+
+| Component     | File                                                              |
+|---------------|-------------------------------------------------------------------|
+| GCC           | [private/downloads/gcc.bzl](../../private/downloads/gcc.bzl)           |
+| glibc         | [private/downloads/glibc.bzl](../../private/downloads/glibc.bzl)       |
+| binutils      | [private/downloads/binutils.bzl](../../private/downloads/binutils.bzl) |
+| Linux headers | [private/downloads/linux_headers.bzl](../../private/downloads/linux_headers.bzl) |
+
+### 2. Find the new artifacts in the GitHub release
+
+List assets in the `binaries` release and filter for the component you rebuilt:
+
+```bash
+gh release view binaries --json assets --jq '.assets[] | .name' | grep <component>
+```
+
+For example, after rebuilding GCC 15.2.0 for `x86_64-linux-gnu`:
+
+```bash
+gh release view binaries --json assets --jq '.assets[] | .name' | grep x86_64-linux-gnu-gcc
+```
+
+Look for artifacts with the **new date** (e.g., `20260222`) alongside the old date (e.g., `20260218`). GCC produces two tarballs per configuration:
+
+- **Bins tarball**: `x86_64-linux-{target}-gcc-{version}-{date}.tar.xz` (compiler binaries)
+- **Libs tarball**: `{target}-gcc-lib-{version}-{date}.tar.xz` (runtime libraries)
+
+Other components produce a single tarball. Consult the download function in the relevant `.bzl` file to see exactly which tarballs are expected.
+
+### 3. Compute SHA256 hashes for the new tarballs
+
+Download each new tarball and compute its hash:
+
+```bash
+# Download to a temporary directory
+gh release download binaries \
+  --pattern "<new-tarball-name>" \
+  --dir /tmp/release-artifacts
+
+# Compute the SHA256 hash
+sha256sum /tmp/release-artifacts/<new-tarball-name>
+```
+
+Repeat for every tarball that needs updating (e.g., both bins and libs for GCC).
+
+### 4. Update `RELEASE_TO_DATE`
+
+In the appropriate `.bzl` file, change the date value for the affected release name.
+
+**Example** (in `gcc.bzl`):
+```python
+# Before
+RELEASE_TO_DATE = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260218",
+}
+
+# After
+RELEASE_TO_DATE = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260222",
+}
+```
+
+### 5. Update `TARBALL_TO_SHA256`
+
+Replace the old tarball entries with the new tarball names and their SHA256 hashes.
+
+**Example** (in `gcc.bzl`):
+```python
+# Before
+TARBALL_TO_SHA256 = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0-20260218.tar.xz": "c8b6430d...",
+    "x86_64-linux-gnu-gcc-lib-15.2.0-20260218.tar.xz": "12e61d6d...",
+}
+
+# After
+TARBALL_TO_SHA256 = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0-20260222.tar.xz": "<new-sha256>",
+    "x86_64-linux-gnu-gcc-lib-15.2.0-20260222.tar.xz": "<new-sha256>",
+}
+```
+
+### 6. Verify the build
+
+Each example is its own Bazel module, so you must build each one individually. The `repo_env` flag format is `{toolchain_name}_{var_name}`, where the toolchain name comes from the `cc_toolchains.declare(name = ...)` tag in each example's `MODULE.bazel`. The examples all use `name = "my_toolchain"`, so the flags are `my_toolchain_target`, `my_toolchain_libc_version`, etc.
+
+```bash
+for example in examples/*/; do
+  (cd "$example" && bazel build \
+    --repo_env=my_toolchain_target=<target> \
+    --repo_env=my_toolchain_libc_version=<libc_version> \
+    --repo_env=my_toolchain_compiler_version=<compiler_version> \
+    //...)
+done
+```
+
+For example, after updating `x86_64-linux-gnu` with GCC 15.2.0 and glibc 2.28:
+
+```bash
+for example in examples/*/; do
+  (cd "$example" && bazel build \
+    --repo_env=my_toolchain_target=x86_64-linux-gnu \
+    --repo_env=my_toolchain_libc_version=2.28 \
+    --repo_env=my_toolchain_compiler_version=15.2.0 \
+    //...)
+done
+```
+
+Note: The `repo_env` flags override the hard-coded defaults in [private/config.bzl](../../private/config.bzl). If the updated component matches the current defaults, the flags are technically redundant but still recommended to be explicit about what you're testing.
+
+## Important: Never Delete Old Artifacts
+
+Old dated tarballs in the `binaries` release **must be preserved**. Previous versions of the module reference the old dates and hashes, and users who haven't updated must continue to be able to download them. This is the reason toolchain binaries are dated — each module version pins to a specific dated build, and only users who update the module get the new tarballs.
+
+## Checklist
+
+- [ ] Identified the correct download file for the rebuilt component
+- [ ] Found the new dated artifacts in the `binaries` GitHub release
+- [ ] Computed SHA256 hashes for all new tarballs
+- [ ] Updated `RELEASE_TO_DATE` with the new date
+- [ ] Updated `TARBALL_TO_SHA256` with the new tarball names and hashes
+- [ ] `bazel build //...` succeeds in each example directory with `repo_env` flags targeting the updated toolchain
+
+## Related Files
+
+- [private/downloads/constants.bzl](../../private/downloads/constants.bzl): Base URL for the `binaries` release
+- [private/downloads/all.bzl](../../private/downloads/all.bzl): Orchestrates all downloads

--- a/examples/boost/MODULE.bazel.lock
+++ b/examples/boost/MODULE.bazel.lock
@@ -335,7 +335,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "t07dFfXroD/Px6unuqd0UIInaJh0Ed03/8uqe2zWhq0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/curl/MODULE.bazel.lock
+++ b/examples/curl/MODULE.bazel.lock
@@ -227,7 +227,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "ytOVRzGgux6+Z+puB7pVw5IBB5VkOHhdx8hQvfCdrNQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/fmt/MODULE.bazel.lock
+++ b/examples/fmt/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "Ogym/dCmE+yG3VjrEigpE5oYAo3HhD1gn3BPgweOWyg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/googletest/MODULE.bazel.lock
+++ b/examples/googletest/MODULE.bazel.lock
@@ -280,7 +280,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "zF9BFQevLFjrq1Y9IIpx6f93/ZXqI7e2NkgYy5deUHs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/grpc/MODULE.bazel.lock
+++ b/examples/grpc/MODULE.bazel.lock
@@ -491,7 +491,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "WxcHEIZnvJ2r2cz5siu2ypOOeLBsfmwcOut2YTNjdRs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/libarchive/MODULE.bazel.lock
+++ b/examples/libarchive/MODULE.bazel.lock
@@ -220,7 +220,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "R86nS74LzgLi08NXWDNo+3iaLNYgMqGPzcdDsDn0bo4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/libuv/MODULE.bazel.lock
+++ b/examples/libuv/MODULE.bazel.lock
@@ -208,7 +208,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "me3fgFonULuSv0lTy5/yk7ZgVtf20+DB7pADs2/mnJw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/nlohmann_json/MODULE.bazel.lock
+++ b/examples/nlohmann_json/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "62/ziX0ezmh6xXvBBjyO/cLoXHFabHTF7Qk3IC6JNhI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/protobuf/MODULE.bazel.lock
+++ b/examples/protobuf/MODULE.bazel.lock
@@ -288,7 +288,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "6ptHlcwHnIvOhaqa6gf388ytOHWRRqj8ZbvzVG0c+Ag=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/sqlite/MODULE.bazel.lock
+++ b/examples/sqlite/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "hmLP2+eWOtQrYKPXKM2vUUap6waUis9xTl4GTYjHe5I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/zlib/MODULE.bazel.lock
+++ b/examples/zlib/MODULE.bazel.lock
@@ -206,7 +206,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "KLh+0S9/jJzkEYXFDdXEVdFfBDFttBOGRsxrdxZmJ1s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/zstd/MODULE.bazel.lock
+++ b/examples/zstd/MODULE.bazel.lock
@@ -208,7 +208,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "hXBlth6g2FbjQh8u+2WFISGzVoZxW3QlUvNh/iY3vVI=",
+        "bzlTransitiveDigest": "bAU/xE9NtijlAGVc36iw79XA1nkqIbWVYOMRkfj/W9s=",
         "usagesDigest": "NRFDpWlXnA3yL2SDjG9Iaxpylu88xhp3HdOgPna5/pA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/private/downloads/gcc.bzl
+++ b/private/downloads/gcc.bzl
@@ -50,10 +50,10 @@ def download_gcc(rctx, config):
     )
 
 RELEASE_TO_DATE = {
-    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260218",
+    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260222",
 }
 
 TARBALL_TO_SHA256 = {
-    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0-20260218.tar.xz": "c8b6430de4346fea5acd09689bda4df49783896944655a2ffdad19699498aa8b",
-    "x86_64-linux-gnu-gcc-lib-15.2.0-20260218.tar.xz": "12e61d6d4166498a776b01c73866c19cce0506a86b05add8b119c7a45376cd19",
+    "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0-20260222.tar.xz": "4a9f7d799aa96efe06ae362f85d87586fabbae619a82c565294d9971717cf0e4",
+    "x86_64-linux-gnu-gcc-lib-15.2.0-20260222.tar.xz": "372c953c9cd8455b2fc541b33ad790622665efc17b4bf128f52f4844c9c6ed1e",
 }


### PR DESCRIPTION
Problem
================================================================================

The GCC 15.2.0 binaries for x86_64-linux-gnu need to be updated to point to the latest rebuild artifacts after a build process fix.

Context
================================================================================

The GCC build process was recently fixed in 1944741 and e276c69. The previous binaries (dated 20260218) were built before these fixes. A rebuild has been performed and the new artifacts (dated 20260222) have been uploaded to the binaries GitHub release.

Solution
================================================================================

Update RELEASE_TO_DATE and TARBALL_TO_SHA256 in private/downloads/gcc.bzl to point to the new 20260222 tarballs with their verified SHA256 hashes.

Rationale
================================================================================

Why not keep the old binaries as default?
--------------------------------------------------------------------------------

The new binaries incorporate build process fixes and should be used by all new consumers of the module. Old dated tarballs remain in the GitHub release for users pinned to previous module versions.

Test Plan
================================================================================

- [x] Downloaded new tarballs and verified SHA256 hashes
- [x] Built all 14 examples with repo_env flags targeting x86_64-linux-gnu, GCC 15.2.0, glibc 2.28 — all succeeded