### PR TITLE
feat: add build_libclang workflow for glibc-linked libclang artifacts

### DIFF
--- a/.github/workflows/build_libclang.yml
+++ b/.github/workflows/build_libclang.yml
@@ -1,0 +1,95 @@
+name: Build libclang
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvm_version:
+        description: 'LLVM version to build'
+        required: true
+        default: '21.1.1'
+        type: string
+      zlib_version:
+        description: 'zlib version to build'
+        required: true
+        default: '1.3.1'
+        type: string
+      gcc_version:
+        description: 'GCC version to use for compilation'
+        required: true
+        default: '15.2.0'
+        type: string
+      glibc_version:
+        description: 'glibc version to link against'
+        required: true
+        default: '2.28'
+        type: string
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_libclang
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  ZLIB_VERSION: ${{ github.event.inputs.zlib_version }}
+  LLVM_VERSION: ${{ github.event.inputs.llvm_version }}
+  GCC_VERSION: ${{ github.event.inputs.gcc_version }}
+  GLIBC_VERSION: ${{ github.event.inputs.glibc_version }}
+  LINUX_VERSION: '6.18'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: $SCRIPTS_DIR/step-1_install_dependencies
+
+      - name: Set up environment
+        run: $SCRIPTS_DIR/environment
+
+      - name: Download zlib source
+        run: $SCRIPTS_DIR/step-2.1_download_zlib_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download LLVM source
+        run: $SCRIPTS_DIR/step-2.2_download_llvm_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install GCC toolchain
+        run: $SCRIPTS_DIR/step-2.3_install_gcc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux headers
+        run: $SCRIPTS_DIR/step-2.4_install_linux_headers
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build zlib
+        run: $SCRIPTS_DIR/step-3_build_zlib
+
+      - name: Build libclang
+        run: $SCRIPTS_DIR/step-4_build_libclang
+
+      - name: Package toolchain
+        run: $SCRIPTS_DIR/step-5_package_toolchain
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v3.2.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: $SCRIPTS_DIR/step-6_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_libclang/Dockerfile
+++ b/.github/workflows/build_libclang/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:latest
+
+# ===========
+# || Setup ||
+# ===========
+ENV SCRIPTS_DIR="/tmp/scripts"
+ENV UTILS_DIR="/tmp/scripts"
+
+COPY .github/workflows/utils/initialize_user $UTILS_DIR/initialize_user
+RUN $UTILS_DIR/initialize_user
+
+USER builder
+WORKDIR /home/builder
+
+COPY .github/workflows/build_libclang/environment $SCRIPTS_DIR/environment
+COPY .github/workflows/utils/download_tarball $UTILS_DIR/download_tarball
+
+# ======================
+# || Build libclang  ||
+# ======================
+COPY .github/workflows/build_libclang/step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
+RUN $SCRIPTS_DIR/step-1_install_dependencies
+
+COPY .github/workflows/utils/install_gh_cli $UTILS_DIR/install_gh_cli
+RUN $UTILS_DIR/install_gh_cli
+
+ARG GH_TOKEN
+ARG ZLIB_VERSION=1.3.1
+COPY .github/workflows/build_libclang/step-2.1_download_zlib_source $SCRIPTS_DIR/step-2.1_download_zlib_source
+RUN $SCRIPTS_DIR/step-2.1_download_zlib_source
+
+ARG LLVM_VERSION=21.1.1
+COPY .github/workflows/build_libclang/step-2.2_download_llvm_source $SCRIPTS_DIR/step-2.2_download_llvm_source
+RUN $SCRIPTS_DIR/step-2.2_download_llvm_source
+
+ARG GCC_VERSION=15.2.0
+ARG GLIBC_VERSION=2.28
+COPY .github/workflows/build_libclang/step-2.3_install_gcc $SCRIPTS_DIR/step-2.3_install_gcc
+RUN $SCRIPTS_DIR/step-2.3_install_gcc
+
+ARG LINUX_VERSION=6.18
+COPY .github/workflows/build_libclang/step-2.4_install_linux_headers $SCRIPTS_DIR/step-2.4_install_linux_headers
+RUN $SCRIPTS_DIR/step-2.4_install_linux_headers
+
+COPY .github/workflows/build_libclang/step-3_build_zlib $SCRIPTS_DIR/step-3_build_zlib
+RUN $SCRIPTS_DIR/step-3_build_zlib
+
+COPY .github/workflows/build_libclang/step-4_build_libclang $SCRIPTS_DIR/step-4_build_libclang
+RUN $SCRIPTS_DIR/step-4_build_libclang
+
+COPY .github/workflows/build_libclang/step-5_package_toolchain $SCRIPTS_DIR/step-5_package_toolchain
+RUN $SCRIPTS_DIR/step-5_package_toolchain

--- a/.github/workflows/build_libclang/build.sh
+++ b/.github/workflows/build_libclang/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euox pipefail
+
+# Usage: Run from repo root with LLVM version, zlib version, and GitHub token
+#   .github/workflows/build_libclang/build.sh <LLVM_VERSION> <ZLIB_VERSION> <GH_TOKEN>
+#
+# Examples:
+#   .github/workflows/build_libclang/build.sh 21.1.1 1.3.1 <token>
+
+docker build \
+    -f .github/workflows/build_libclang/Dockerfile \
+    --build-arg LLVM_VERSION="${1}" \
+    --build-arg ZLIB_VERSION="${2}" \
+    --build-arg GH_TOKEN="${3}" \
+    -t libclang \
+    .
+
+CONTAINER_ID=$(docker create libclang)
+docker cp "${CONTAINER_ID}:/tmp/artifacts/." .
+docker rm "${CONTAINER_ID}"

--- a/.github/workflows/build_libclang/environment
+++ b/.github/workflows/build_libclang/environment
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euox pipefail
+
+# ==============================
+# || Setup Source Directories ||
+# ==============================
+export ZLIB_SOURCE="/tmp/zlib-source"
+export LLVM_SOURCE="/tmp/llvm-source"
+
+mkdir -p ${ZLIB_SOURCE}
+mkdir -p ${LLVM_SOURCE}
+
+# =============================
+# || Setup Build Directories ||
+# =============================
+export ZLIB_DIR="/tmp/zlib"
+export LLVM_DIR="/tmp/llvm"
+
+mkdir -p ${ZLIB_DIR}
+mkdir -p ${LLVM_DIR}
+
+# ====================
+# || GCC Toolchain  ||
+# ====================
+export GCC_DIR="/tmp/gcc"
+export GCC_SYSROOT="${GCC_DIR}"
+export GCC_BINS="${GCC_DIR}/bin/"
+
+mkdir -p ${GCC_DIR}
+
+# ==============================
+# || Setup Output Directories ||
+# ==============================
+export ARTIFACTS_DIR="/tmp/artifacts"
+
+mkdir -p ${ARTIFACTS_DIR}
+
+# Ensures that ARTIFACTS_DIR is available to provenance attestation in
+# the github actions workflow.
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "${GITHUB_ENV}"
+fi

--- a/.github/workflows/build_libclang/step-1_install_dependencies
+++ b/.github/workflows/build_libclang/step-1_install_dependencies
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+sudo apt update
+DEBIAN_FRONTEND=noninteractive sudo apt install -y \
+    build-essential \
+    git \
+    ninja-build \
+    python3 \
+    wget \
+    cmake

--- a/.github/workflows/build_libclang/step-2.1_download_zlib_source
+++ b/.github/workflows/build_libclang/step-2.1_download_zlib_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+"${UTILS_DIR}/download_tarball" "zlib-${ZLIB_VERSION}.tar.xz" "${ZLIB_SOURCE}"

--- a/.github/workflows/build_libclang/step-2.2_download_llvm_source
+++ b/.github/workflows/build_libclang/step-2.2_download_llvm_source
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+"${UTILS_DIR}/download_tarball" "llvm-project-${LLVM_VERSION}.tar.xz" "${LLVM_SOURCE}"

--- a/.github/workflows/build_libclang/step-2.3_install_gcc
+++ b/.github/workflows/build_libclang/step-2.3_install_gcc
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+# Uses glibc-based GCC so that libclang is dynamically linked against glibc.
+"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-gnu-gcc-${GCC_VERSION}-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-gcc-lib-${GCC_VERSION}-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-gnu-binutils-2.45-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-glibc-${GLIBC_VERSION}-" "${GCC_DIR}"

--- a/.github/workflows/build_libclang/step-2.4_install_linux_headers
+++ b/.github/workflows/build_libclang/step-2.4_install_linux_headers
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+"${UTILS_DIR}/download_tarball" "x86_64-linux-headers-${LINUX_VERSION}-" "${GCC_DIR}"

--- a/.github/workflows/build_libclang/step-3_build_zlib
+++ b/.github/workflows/build_libclang/step-3_build_zlib
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd ${ZLIB_DIR}
+
+cp -r ${ZLIB_SOURCE}/* .
+
+export PATH=${GCC_BINS}:$PATH
+export CC="${GCC_BINS}/x86_64-linux-gnu-gcc"
+export CXX="${GCC_BINS}/x86_64-linux-gnu-g++"
+export CFLAGS="-fPIC --sysroot=${GCC_SYSROOT}"
+export CXXFLAGS="--sysroot=${GCC_SYSROOT}"
+
+./configure --static --prefix=${GCC_SYSROOT}/usr
+make
+make install
+
+popd

--- a/.github/workflows/build_libclang/step-4_build_libclang
+++ b/.github/workflows/build_libclang/step-4_build_libclang
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd ${LLVM_DIR}
+
+cp -r ${LLVM_SOURCE}/* .
+
+export PATH=${GCC_BINS}:$PATH
+
+cmake -G Ninja -S llvm -B build \
+    -DLLVM_ENABLE_PROJECTS="clang" \
+    -DLIBCLANG_BUILD_STATIC=ON \
+    -DLLVM_ENABLE_PIC=ON \
+    -DLLVM_BUILD_LLVM_DYLIB=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DLLVM_ENABLE_ZLIB=ON \
+    -DCMAKE_C_COMPILER="${GCC_BINS}/x86_64-linux-gnu-gcc" \
+    -DCMAKE_CXX_COMPILER="${GCC_BINS}/x86_64-linux-gnu-g++" \
+    -DCMAKE_SYSROOT="${GCC_SYSROOT}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${ARTIFACTS_DIR}" \
+    -DLLVM_ENABLE_WARNINGS=OFF \
+    -DCMAKE_SKIP_RPATH=TRUE \
+    -DLLVM_PARALLEL_LINK_JOBS=2
+
+ninja -C build -j$(( $(nproc) / 2 > 0 ? $(nproc) / 2 : 1 ))
+
+ninja -C build install
+
+popd

--- a/.github/workflows/build_libclang/step-5_package_toolchain
+++ b/.github/workflows/build_libclang/step-5_package_toolchain
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+pushd ${ARTIFACTS_DIR}
+
+RELEASE_NAME="x86_64-linux-libclang-${LLVM_VERSION}-$(date +%Y%m%d)"
+echo $RELEASE_NAME > ${ARTIFACTS_DIR}/release_name
+
+XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${RELEASE_NAME}.tar.xz" \
+    lib/libclang* \
+    lib/clang/ \
+    include/clang-c/
+
+popd

--- a/.github/workflows/build_libclang/step-6_upload_release
+++ b/.github/workflows/build_libclang/step-6_upload_release
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euox pipefail
+source ${SCRIPTS_DIR}/environment
+
+gh release upload binaries \
+    ${ARTIFACTS_DIR}/*.tar.xz \
+    --clobber


### PR DESCRIPTION
## Summary

- Adds a new `build_libclang` workflow producing `libclang.so`, `libclang.a`, C API headers (`include/clang-c/`), and builtin headers (`lib/clang/`)
- Uses glibc-based GCC (`x86_64-linux-gnu`) linked against glibc 2.28 for runtime compatibility with consumers that load libclang via dlopen/FFI
- Follows standard toolchain build patterns: `download_tarball`, `install_gh_cli`, `initialize_user`, `gh release upload binaries --clobber`

## Test plan

- [x] Verified local Docker build completes successfully
- [ ] Run workflow via `workflow_dispatch` with default versions (LLVM 21.1.1, zlib 1.3.1, GCC 15.2.0, glibc 2.28)
- [ ] Verify artifact contains `lib/libclang.so*`, `lib/libclang.a`, `include/clang-c/`, `lib/clang/`
- [ ] Verify `ldd lib/libclang.so` shows glibc dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)