### PR TITLE
feat: add aarch64 support to binutils build scripts

### DIFF
--- a/.github/workflows/build_binutils/Dockerfile
+++ b/.github/workflows/build_binutils/Dockerfile
@@ -19,6 +19,8 @@ COPY .github/workflows/utils/download_tarball $UTILS_DIR/download_tarball
 # ====================
 # || Build binutils ||
 # ====================
+ARG TARGET=x86_64-linux-gnu
+
 COPY .github/workflows/build_binutils/step-1_install_dependencies $SCRIPTS_DIR/step-1_install_dependencies
 RUN $SCRIPTS_DIR/step-1_install_dependencies
 
@@ -40,7 +42,6 @@ RUN $SCRIPTS_DIR/step-2.3_patch_binutils_source
 COPY .github/workflows/build_binutils/step-3.1_build_zlib $SCRIPTS_DIR/step-3.1_build_zlib
 RUN $SCRIPTS_DIR/step-3.1_build_zlib
 
-ARG TARGET=x86_64-linux-gnu
 COPY .github/workflows/build_binutils/step-3.2_build_binutils $SCRIPTS_DIR/step-3.2_build_binutils
 RUN $SCRIPTS_DIR/step-3.2_build_binutils
 

--- a/.github/workflows/build_binutils/environment
+++ b/.github/workflows/build_binutils/environment
@@ -6,6 +6,7 @@ export ARTIFACTS_DIR="/tmp/artifacts"
 export BINUTILS_SOURCE="/tmp/binutils-source"
 export ZLIB_SOURCE="/tmp/zlib-source"
 export BINUTILS_ARTIFACTS="/tmp/binutils-artifacts"
+export BUILD_ARCH=${TARGET%%-*}
 
 mkdir -p "${BUILD_TOOLS}"
 mkdir -p "${ARTIFACTS_DIR}"

--- a/.github/workflows/build_binutils/step-3.1_build_zlib
+++ b/.github/workflows/build_binutils/step-3.1_build_zlib
@@ -8,7 +8,7 @@ cd ${ZLIB_BUILD}
 
 env CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
     LDFLAGS="-L${BUILD_TOOLS}/lib" \
-    CHOST=x86_64-linux-gnu \
+    CHOST=${TARGET%%-*}-linux-gnu \
     ${ZLIB_SOURCE}/configure \
         --prefix=${BUILD_TOOLS} \
         --static

--- a/.github/workflows/build_binutils/step-3.2_build_binutils
+++ b/.github/workflows/build_binutils/step-3.2_build_binutils
@@ -10,8 +10,8 @@ CONFIGURE_FLAGS=()
 
 # System triples: build/host use GNU (static linking makes host portable), target musl
 # Set --host and --target to different things to force cross toolchain builds
-CONFIGURE_FLAGS+=(--build=x86_64-pc-linux-gnu)
-CONFIGURE_FLAGS+=(--host=x86_64-pc-linux-gnu)
+CONFIGURE_FLAGS+=(--build=${BUILD_ARCH}-pc-linux-gnu)
+CONFIGURE_FLAGS+=(--host=${BUILD_ARCH}-pc-linux-gnu)
 CONFIGURE_FLAGS+=(--target=${TARGET})
 
 # The --with-sysroot flag enables sysroot support in the linker. When binutils is built with this

--- a/.github/workflows/build_binutils/step-4_package_binutils
+++ b/.github/workflows/build_binutils/step-4_package_binutils
@@ -19,7 +19,7 @@ pushd "${BINUTILS_ARTIFACTS}"
 # Adding datetime allows us to update/rebuild toolchain artifacts while
 # maintaining existing artifacts for backward compatibility.
 DATE=$(date +%Y%m%d)
-PACKAGE_NAME="x86_64-linux-${TARGET}-binutils-${BINUTILS_VERSION}-${DATE}.tar.xz"
+PACKAGE_NAME="${BUILD_ARCH}-linux-${TARGET}-binutils-${BINUTILS_VERSION}-${DATE}.tar.xz"
 
 XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" .
 

--- a/.github/workflows/build_binutils_aarch64.yml
+++ b/.github/workflows/build_binutils_aarch64.yml
@@ -1,4 +1,4 @@
-name: Build binutils
+name: Build binutils (aarch64)
 
 on:
   workflow_dispatch:
@@ -11,13 +11,13 @@ on:
       target:
         description: 'Target triplet'
         required: true
-        default: 'x86_64-linux-gnu'
+        default: 'aarch64-linux-gnu'
         type: choice
         options:
-          - x86_64-linux-gnu
-          - x86_64-bootstrap-linux-gnu
-          - x86_64-linux-musl
-          - x86_64-bootstrap-linux-musl
+          - aarch64-linux-gnu
+          - aarch64-bootstrap-linux-gnu
+          - aarch64-linux-musl
+          - aarch64-bootstrap-linux-musl
 
 permissions:
   # Required for uploading GitHub releases
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         binutils_version: ${{ fromJson(github.event.inputs.binutils_versions) }}
@@ -76,7 +76,7 @@ jobs:
         run: $SCRIPTS_DIR/step-4_package_binutils
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v4.1.0
+        uses: actions/attest-build-provenance@v3.2.0
         with:
           subject-path: |
             ${{ env.ARTIFACTS_DIR }}/*.tar.xz

--- a/.github/workflows/build_binutils_x86_64.yml
+++ b/.github/workflows/build_binutils_x86_64.yml
@@ -1,0 +1,87 @@
+name: Build binutils (x86_64)
+
+on:
+  workflow_dispatch:
+    inputs:
+      binutils_versions:
+        description: 'JSON array of binutils versions (e.g., ["2.41", "2.42", "2.43"])'
+        required: true
+        default: '["2.45"]'
+        type: string
+      target:
+        description: 'Target triplet'
+        required: true
+        default: 'x86_64-linux-gnu'
+        type: choice
+        options:
+          - x86_64-linux-gnu
+          - x86_64-bootstrap-linux-gnu
+          - x86_64-linux-musl
+          - x86_64-bootstrap-linux-musl
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_binutils
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  PATCHES_DIR: ${{ github.workspace }}/.github/workflows/build_binutils/patches
+  TARGET: ${{ github.event.inputs.target }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        binutils_version: ${{ fromJson(github.event.inputs.binutils_versions) }}
+      fail-fast: false
+
+    env:
+      BINUTILS_VERSION: ${{ matrix.binutils_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: $SCRIPTS_DIR/step-1_install_dependencies
+
+      - name: Set up environment
+        run: $SCRIPTS_DIR/environment
+
+      - name: Download zlib source
+        run: $SCRIPTS_DIR/step-2.1_download_zlib_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download binutils source
+        run: $SCRIPTS_DIR/step-2.2_download_binutils_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Patch binutils source
+        run: $SCRIPTS_DIR/step-2.3_patch_binutils_source
+
+      - name: Build zlib
+        run: $SCRIPTS_DIR/step-3.1_build_zlib
+
+      - name: Build binutils
+        run: $SCRIPTS_DIR/step-3.2_build_binutils
+
+      - name: Package binutils
+        run: $SCRIPTS_DIR/step-4_package_binutils
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: $SCRIPTS_DIR/step-5_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/utils/install_gh_cli
+++ b/.github/workflows/utils/install_gh_cli
@@ -5,6 +5,10 @@ set -euox pipefail
 # Ubuntu package version is too old, so install from GitHub releases
 # We can assume the actions runner has a good enough version of gh so we only need it in the dockerfile
 GH_VERSION="2.83.2"
-wget "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz"
-tar -xzf "gh_${GH_VERSION}_linux_amd64.tar.gz"
-sudo install "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+case $(uname -m) in
+    x86_64)  GH_ARCH="amd64" ;;
+    aarch64) GH_ARCH="arm64" ;;
+esac
+wget "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
+tar -xzf "gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
+sudo install "gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" /usr/local/bin/gh


### PR DESCRIPTION
Problem
================================================================================

The binutils build scripts and Dockerfile cannot build on aarch64 hosts, blocking initial aarch64 toolchain support.

Context
================================================================================

What is hardcoded to x86_64?
--------------------------------------------------------------------------------

The build scripts hardcode x86_64 in three places: the zlib CHOST triplet, the binutils --build/--host configure flags, and the output package name. The Dockerfile declares the TARGET arg too late, after steps that source the environment file. The shared install_gh_cli utility hardcodes the amd64 GitHub CLI binary.

What fails on aarch64?
--------------------------------------------------------------------------------

The environment script fails with "TARGET: unbound variable" because the Dockerfile's ARG TARGET declaration comes after steps that source it. Even after fixing that, the gh CLI binary fails with "Exec format error" because the x86_64 binary can't run on aarch64.

Solution
================================================================================

- Add BUILD_ARCH (derived from TARGET) to the environment file so all scripts share a single definition
- Replace hardcoded x86_64 triplets in zlib, binutils configure, and package naming with BUILD_ARCH
- Move ARG TARGET earlier in the Dockerfile so it's available to all RUN steps that source the environment
- Update install_gh_cli to select the correct binary via uname -m

Rationale
================================================================================

Why derive BUILD_ARCH from TARGET instead of uname -m? --------------------------------------------------------------------------------

Only native builds are supported for now (aarch64-on-aarch64), so the host architecture always matches the target architecture. Deriving from TARGET keeps the build/host/target relationship explicit and consistent with the existing pattern of passing TARGET as a build arg.

Why does install_gh_cli use uname -m instead of BUILD_ARCH? --------------------------------------------------------------------------------

The gh CLI is a host tool that must match the build machine, not the cross-compilation target. It's also a shared utility used across all workflow Dockerfiles, so it can't source any workflow-specific environment file.