### PR TITLE
feat: add aarch64 support to GCC build scripts

### DIFF
--- a/.github/workflows/build_gcc/environment
+++ b/.github/workflows/build_gcc/environment
@@ -10,6 +10,14 @@ else
     export BOOTSTRAP="false"
 fi
 
+export BUILD_ARCH=${TARGET%%-*}
+
+# Linux kernel ARCH values differ from GNU triplet arch names
+case ${BUILD_ARCH} in
+    x86_64)  export LINUX_ARCH="x86" ;;
+    aarch64) export LINUX_ARCH="arm64" ;;
+esac
+
 # ==============================
 # || Setup Source Directories ||
 # ==============================

--- a/.github/workflows/build_gcc/step-3.1_install_linux_headers
+++ b/.github/workflows/build_gcc/step-3.1_install_linux_headers
@@ -10,7 +10,7 @@ make -C ${LINUX_SOURCE} \
     HOSTCC=gcc \
     CROSS_COMPILE=${TARGET}- \
     O=${LINUX_BUILD} \
-    ARCH=x86 \
+    ARCH=${LINUX_ARCH} \
     INSTALL_HDR_PATH=${BUILD_TOOLS}/usr \
     V=0 \
     headers_install

--- a/.github/workflows/build_gcc/step-3.2_install_binutils
+++ b/.github/workflows/build_gcc/step-3.2_install_binutils
@@ -3,18 +3,18 @@ set -euox pipefail
 source ${SCRIPTS_DIR}/environment
 
 if [[ "${TARGET}" == *-gnu ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-binutils-2.45-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-gnu-binutils-2.45-" "${BUILD_TOOLS}"
 elif [[ "${TARGET}" == *-musl ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-musl-binutils-2.45-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-musl-binutils-2.45-" "${BUILD_TOOLS}"
 fi
 
 # Full builds need non-bootstrap binutils so that target-prefixed tools
-# (e.g. x86_64-linux-musl-ld) are available for GCC's configure scripts.
-# Bootstrap binutils only provide x86_64-bootstrap-linux-musl-* prefixed tools.
+# (e.g. ${BUILD_ARCH}-linux-musl-ld) are available for GCC's configure scripts.
+# Bootstrap binutils only provide ${BUILD_ARCH}-bootstrap-linux-musl-* prefixed tools.
 if [[ "${BOOTSTRAP}" == "false" ]]; then
     if [[ "${TARGET}" == *-gnu ]]; then
-        "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-gnu-binutils-2.45-" "${BUILD_TOOLS}"
+        "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-linux-gnu-binutils-2.45-" "${BUILD_TOOLS}"
     elif [[ "${TARGET}" == *-musl ]]; then
-        "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-musl-binutils-2.45-" "${BUILD_TOOLS}"
+        "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-linux-musl-binutils-2.45-" "${BUILD_TOOLS}"
     fi
 fi

--- a/.github/workflows/build_gcc/step-3.3_install_libc
+++ b/.github/workflows/build_gcc/step-3.3_install_libc
@@ -10,7 +10,7 @@ fi
 
 if [[ "${TARGET}" == *-gnu ]]; then
     # we build against an old glibc to make sure the libgcc and libstdc++ encode a minimal glibc version
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-gnu-glibc-2.28-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-gnu-glibc-2.28-" "${BUILD_TOOLS}"
 elif [[ "${TARGET}" == *-musl ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-musl-musl-1.2.5-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-musl-musl-1.2.5-" "${BUILD_TOOLS}"
 fi

--- a/.github/workflows/build_gcc/step-3.4_install_gcc
+++ b/.github/workflows/build_gcc/step-3.4_install_gcc
@@ -9,8 +9,8 @@ if [[ "${BOOTSTRAP}" == "true" ]]; then
 fi
 
 if [[ "${TARGET}" == *-gnu ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-${GCC_VERSION}-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-gnu-gcc-${GCC_VERSION}-" "${BUILD_TOOLS}"
 elif [[ "${TARGET}" == *-musl ]]; then
-    "${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-musl-gcc-${GCC_VERSION}-" "${BUILD_TOOLS}"
+    "${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-musl-gcc-${GCC_VERSION}-" "${BUILD_TOOLS}"
 fi
 

--- a/.github/workflows/build_gcc/step-4.1_build_gmp
+++ b/.github/workflows/build_gcc/step-4.1_build_gmp
@@ -12,8 +12,8 @@ env CC_FOR_BUILD=gcc \
     CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include -std=gnu17 -fexceptions" \
     LDFLAGS="-L${BUILD_TOOLS}/lib" \
     ${GMP_SOURCE}/configure \
-        --build=x86_64-linux-gnu \
-        --host=x86_64-linux-gnu \
+        --build=${BUILD_ARCH}-linux-gnu \
+        --host=${BUILD_ARCH}-linux-gnu \
         --prefix=${BUILD_TOOLS} \
         --enable-fft \
         --enable-cxx \

--- a/.github/workflows/build_gcc/step-4.2_build_isl
+++ b/.github/workflows/build_gcc/step-4.2_build_isl
@@ -13,8 +13,8 @@ env CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
     CXXFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
     LDFLAGS="-L${BUILD_TOOLS}/lib" \
     ${ISL_SOURCE}/configure \
-        --build=x86_64-linux-gnu \
-        --host=x86_64-linux-gnu \
+        --build=${BUILD_ARCH}-linux-gnu \
+        --host=${BUILD_ARCH}-linux-gnu \
         --prefix=${BUILD_TOOLS} \
         --disable-shared \
         --enable-static \

--- a/.github/workflows/build_gcc/step-4.3_build_mpfr
+++ b/.github/workflows/build_gcc/step-4.3_build_mpfr
@@ -15,8 +15,8 @@ env CC=gcc \
     CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
     LDFLAGS="-L${BUILD_TOOLS}/lib" \
     ${MPFR_SOURCE}/configure \
-        --build=x86_64-linux-gnu \
-        --host=x86_64-linux-gnu \
+        --build=${BUILD_ARCH}-linux-gnu \
+        --host=${BUILD_ARCH}-linux-gnu \
         --prefix=${BUILD_TOOLS} \
         --enable-thread-safe \
         --with-gmp=${BUILD_TOOLS} \

--- a/.github/workflows/build_gcc/step-4.4_build_mpc
+++ b/.github/workflows/build_gcc/step-4.4_build_mpc
@@ -13,8 +13,8 @@ cd ${MPC_BUILD}
 env CFLAGS="-O3 -pipe -I${BUILD_TOOLS}/include" \
     LDFLAGS="-L${BUILD_TOOLS}/lib" \
     ${MPC_SOURCE}/configure \
-        --build=x86_64-linux-gnu \
-        --host=x86_64-linux-gnu \
+        --build=${BUILD_ARCH}-linux-gnu \
+        --host=${BUILD_ARCH}-linux-gnu \
         --prefix=${BUILD_TOOLS} \
         --with-gmp=${BUILD_TOOLS} \
         --with-mpfr=${BUILD_TOOLS} \

--- a/.github/workflows/build_gcc/step-4.5_build_gcc
+++ b/.github/workflows/build_gcc/step-4.5_build_gcc
@@ -13,12 +13,12 @@ CONFIGURE_FLAGS=()
 # The bootstrap vendor in --build forces GCC's cross-compilation install layout for all targets.
 # See: docs/lore/gcc/native_vs_cross_install_layout.md
 if [[ "${BOOTSTRAP}" == "true" ]]; then
-    CONFIGURE_FLAGS+=(--build=x86_64-linux-gnu)
-    CONFIGURE_FLAGS+=(--host=x86_64-linux-gnu)
+    CONFIGURE_FLAGS+=(--build=${BUILD_ARCH}-linux-gnu)
+    CONFIGURE_FLAGS+=(--host=${BUILD_ARCH}-linux-gnu)
     CONFIGURE_FLAGS+=(--target=${TARGET})
 else
-    CONFIGURE_FLAGS+=(--build=x86_64-bootstrap-linux-gnu)
-    CONFIGURE_FLAGS+=(--host=x86_64-bootstrap-linux-gnu)
+    CONFIGURE_FLAGS+=(--build=${BUILD_ARCH}-bootstrap-linux-gnu)
+    CONFIGURE_FLAGS+=(--host=${BUILD_ARCH}-bootstrap-linux-gnu)
     CONFIGURE_FLAGS+=(--target=${TARGET})
 fi
 

--- a/.github/workflows/build_gcc/step-5_package_toolchain
+++ b/.github/workflows/build_gcc/step-5_package_toolchain
@@ -14,7 +14,7 @@ if [[ "${BOOTSTRAP}" == "true" ]]; then
     # ===========================
     # || Package bootstrap gcc ||
     # ===========================
-    tar cJf "${ARTIFACTS_DIR}/x86_64-linux-${TARGET}-gcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" .
+    tar cJf "${ARTIFACTS_DIR}/${BUILD_ARCH}-linux-${TARGET}-gcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" .
 else
     # =======================
     # || Package gcc libs  ||
@@ -30,7 +30,7 @@ else
     # =================
     # || Package gcc ||
     # =================
-    tar cJf "${ARTIFACTS_DIR}/x86_64-linux-${TARGET}-gcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" \
+    tar cJf "${ARTIFACTS_DIR}/${BUILD_ARCH}-linux-${TARGET}-gcc-${GCC_FULL_VERSION}-${DATE}.tar.xz" \
         bin/ \
         libexec/ \
         share/

--- a/.github/workflows/build_gcc_aarch64.yml
+++ b/.github/workflows/build_gcc_aarch64.yml
@@ -1,0 +1,129 @@
+name: Build GCC (aarch64)
+
+on:
+  workflow_dispatch:
+    inputs:
+      gcc_versions:
+        description: 'JSON array of GCC versions (e.g., ["14.2.0", "15.2.0"])'
+        required: true
+        default: '["15.2.0"]'
+        type: string
+      target:
+        description: 'Target triplet'
+        required: true
+        default: 'aarch64-linux-gnu'
+        type: choice
+        options:
+          - aarch64-linux-gnu
+          - aarch64-bootstrap-linux-gnu
+          - aarch64-linux-musl
+          - aarch64-bootstrap-linux-musl
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_gcc
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  TARGET: ${{ github.event.inputs.target }}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        gcc_version: ${{ fromJson(github.event.inputs.gcc_versions) }}
+      fail-fast: false
+
+    env:
+      GCC_VERSION: ${{ matrix.gcc_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: $SCRIPTS_DIR/step-01_install_dependencies
+
+      - name: Set up environment
+        run: $SCRIPTS_DIR/environment
+
+      - name: Download GMP source
+        run: $SCRIPTS_DIR/step-2.1_download_gmp_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download MPFR source
+        run: $SCRIPTS_DIR/step-2.2_download_mpfr_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download ISL source
+        run: $SCRIPTS_DIR/step-2.3_download_isl_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download MPC source
+        run: $SCRIPTS_DIR/step-2.4_download_mpc_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download GCC source
+        run: $SCRIPTS_DIR/step-2.5_download_gcc_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download Linux kernel headers source
+        run: $SCRIPTS_DIR/step-2.6_download_linux_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux kernel headers
+        run: $SCRIPTS_DIR/step-3.1_install_linux_headers
+
+      - name: Install binutils
+        run: $SCRIPTS_DIR/step-3.2_install_binutils
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install toolchain libc
+        run: $SCRIPTS_DIR/step-3.3_install_libc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install bootstrapping gcc
+        run: $SCRIPTS_DIR/step-3.4_install_gcc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build GMP
+        run: $SCRIPTS_DIR/step-4.1_build_gmp
+
+      - name: Build ISL
+        run: $SCRIPTS_DIR/step-4.2_build_isl
+
+      - name: Build MPFR
+        run: $SCRIPTS_DIR/step-4.3_build_mpfr
+
+      - name: Build MPC
+        run: $SCRIPTS_DIR/step-4.4_build_mpc
+
+      - name: Build GCC
+        run: $SCRIPTS_DIR/step-4.5_build_gcc
+
+      - name: Package toolchain
+        run: $SCRIPTS_DIR/step-5_package_toolchain
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: $SCRIPTS_DIR/step-6_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_gcc_x86_64.yml
+++ b/.github/workflows/build_gcc_x86_64.yml
@@ -1,4 +1,4 @@
-name: Build GCC
+name: Build GCC (x86_64)
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Problem
================================================================================

The GCC build scripts and workflow cannot build on aarch64 hosts, blocking the next step in aarch64 toolchain support after binutils.

Context
================================================================================

What is hardcoded to x86_64?
--------------------------------------------------------------------------------

The GCC build has x86_64 hardcoded in ~15 places across 10 scripts: build/host triplets in dependency builds (gmp, isl, mpfr, mpc), GCC configure flags, bootstrap toolchain tarball download names, libc tarball names, Linux kernel headers ARCH value, and output package names.

What is the dependency chain?
--------------------------------------------------------------------------------

Building bootstrap GCC for aarch64 requires aarch64 binutils artifacts, which are now available. Full GCC builds additionally require aarch64 glibc/musl artifacts (not yet available, future work). The bootstrap GCC is the next artifact needed to unblock the rest of the chain.

Solution
================================================================================

- Add BUILD_ARCH (derived from TARGET) and LINUX_ARCH (kernel arch mapping) to the environment file
- Replace all hardcoded x86_64 triplets with BUILD_ARCH in:
  - Dependency library builds (gmp, isl, mpfr, mpc --build/--host)
  - GCC configure (--build/--host for both bootstrap and full builds)
  - Bootstrap toolchain downloads (binutils, gcc tarball name prefixes)
  - Libc downloads (glibc, musl tarball name prefixes)
  - Linux kernel headers (ARCH=x86 -> ARCH=${LINUX_ARCH})
  - Package naming (x86_64-linux- prefix)
- Split build_gcc.yml into build_gcc_x86_64.yml (ubuntu-latest) and build_gcc_aarch64.yml (ubuntu-24.04-arm)

Rationale
================================================================================

Why add LINUX_ARCH separately from BUILD_ARCH?
--------------------------------------------------------------------------------

The Linux kernel uses different architecture names than GNU triplets: x86_64 maps to "x86" and aarch64 maps to "arm64". A simple case statement in the environment file keeps this mapping centralized.

Why the same pattern as binutils?
--------------------------------------------------------------------------------

Using BUILD_ARCH derived from TARGET maintains consistency with the binutils changes and keeps the host=target assumption explicit for native-only builds.