### PR TITLE
feat: add aarch64 support to glibc build scripts

### DIFF
--- a/.github/workflows/build_glibc/Dockerfile
+++ b/.github/workflows/build_glibc/Dockerfile
@@ -21,6 +21,8 @@ COPY .github/workflows/utils/download_tarball $UTILS_DIR/
 # =================
 # || Build glibc ||
 # =================
+ARG TARGET=x86_64-linux-gnu
+
 COPY .github/workflows/build_glibc/step-1_install_dependencies $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-1_install_dependencies
 

--- a/.github/workflows/build_glibc/build.sh
+++ b/.github/workflows/build_glibc/build.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -euox pipefail
 
-# Usage: Run from repo root with GitHub token
-#   .github/workflows/build_glibc/build.sh <GLIBC_VERSION> <LINUX_VERSION> <GH_TOKEN>
-#   .github/workflows/build_glibc/build.sh 2.28 6.18 <GH_TOKEN>
+# Usage: Run from repo root with glibc version, target, and GitHub token
+#   .github/workflows/build_glibc/build.sh <GLIBC_VERSION> <LINUX_VERSION> <TARGET> <GH_TOKEN>
+#   .github/workflows/build_glibc/build.sh 2.28 6.18 aarch64-linux-gnu <GH_TOKEN>
 
 docker build \
     -f .github/workflows/build_glibc/Dockerfile \
-    --build-arg GLIBC_VERSION=$1 \
-    --build-arg LINUX_VERSION=$2 \
-    --build-arg GH_TOKEN=$3 \
+    --build-arg GLIBC_VERSION="${1}" \
+    --build-arg LINUX_VERSION="${2}" \
+    --build-arg TARGET="${3}" \
+    --build-arg GH_TOKEN="${4}" \
     -t glibc \
     .
 

--- a/.github/workflows/build_glibc/environment
+++ b/.github/workflows/build_glibc/environment
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euox pipefail
 
+export BUILD_ARCH=${TARGET%%-*}
+
+# Linux kernel ARCH values differ from GNU triplet arch names
+case ${BUILD_ARCH} in
+    x86_64)  export LINUX_ARCH="x86" ;;
+    aarch64) export LINUX_ARCH="arm64" ;;
+esac
+
 export SYSROOT_DIR="/tmp/sysroot"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export GLIBC_SOURCE="/tmp/glibc-source"

--- a/.github/workflows/build_glibc/step-3.1_install_linux_headers
+++ b/.github/workflows/build_glibc/step-3.1_install_linux_headers
@@ -10,7 +10,7 @@ pushd "${LINUX_SOURCE}"
 make \
     "HOSTCC=gcc" \
     "O=${LINUX_BUILD_DIR}" \
-    "ARCH=x86" \
+    "ARCH=${LINUX_ARCH}" \
     "INSTALL_HDR_PATH=${SYSROOT_DIR}/usr" \
     "V=0" \
     headers_install

--- a/.github/workflows/build_glibc/step-3.2_install_gcc
+++ b/.github/workflows/build_glibc/step-3.2_install_gcc
@@ -2,5 +2,5 @@
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
 
-"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-binutils-2.45-" "${SYSROOT_DIR}"
-"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-bootstrap-linux-gnu-gcc-15.2.0-" "${SYSROOT_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-gnu-binutils-2.45-" "${SYSROOT_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-gnu-gcc-15.2.0-" "${SYSROOT_DIR}"

--- a/.github/workflows/build_glibc/step-4_build_glibc
+++ b/.github/workflows/build_glibc/step-4_build_glibc
@@ -9,23 +9,34 @@ mkdir -p "${GLIBC_BUILD_DIR}"
 
 pushd "${GLIBC_BUILD_DIR}"
 
+# -fcf-protection controls CET (Control-flow Enforcement Technology), an x86-specific feature.
+# On aarch64, GCC doesn't recognize this flag.
+ARCH_CC_FLAGS=""
+ARCH_CFLAGS=""
+CONFIGURE_FLAGS=()
+if [[ "${BUILD_ARCH}" == "x86_64" ]]; then
+    ARCH_CC_FLAGS="-fcf-protection=none"
+    ARCH_CFLAGS="-fcf-protection=none"
+    CONFIGURE_FLAGS+=(--disable-cet)
+fi
+
 # ===============
 # || Configure ||
 # ===============
 env BUILD_CC=gcc \
-    CC="x86_64-bootstrap-linux-gnu-gcc -O3 -fcommon -U_FORTIFY_SOURCE -Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-implicit-int -fcf-protection=none" \
-    CFLAGS="-fcf-protection=none" \
-    AR=x86_64-bootstrap-linux-gnu-ar \
-    RANLIB=x86_64-bootstrap-linux-gnu-ranlib \
+    CC="${BUILD_ARCH}-bootstrap-linux-gnu-gcc -O3 -fcommon -U_FORTIFY_SOURCE -Wno-missing-attributes -Wno-array-bounds -Wno-array-parameter -Wno-stringop-overflow -Wno-maybe-uninitialized -Wno-implicit-int ${ARCH_CC_FLAGS}" \
+    CFLAGS="${ARCH_CFLAGS}" \
+    AR=${BUILD_ARCH}-bootstrap-linux-gnu-ar \
+    RANLIB=${BUILD_ARCH}-bootstrap-linux-gnu-ranlib \
     ${GLIBC_SOURCE}/configure \
         --prefix=/usr \
-        --host=x86_64-linux-gnu \
+        --host=${BUILD_ARCH}-linux-gnu \
         --without-cvs \
         --disable-profile \
         --without-gd \
         --with-headers=${SYSROOT_DIR}/usr/include \
         --disable-debug \
-        --disable-cet \
+        ${CONFIGURE_FLAGS[@]:+"${CONFIGURE_FLAGS[@]}"} \
         --disable-sanity-checks \
         --enable-obsolete-rpc \
         --enable-kernel="" \

--- a/.github/workflows/build_glibc/step-5_package_glibc
+++ b/.github/workflows/build_glibc/step-5_package_glibc
@@ -4,8 +4,8 @@ source ${SCRIPTS_DIR}/environment
 
 pushd "${GLIBC_ARTIFACTS}"
 
-mkdir lib
-mkdir usr/lib
+mkdir -p lib
+mkdir -p usr/lib
 
 MESSAGE="See https://github.com/reutermj/toolchains_cc/blob/main/docs/lore/gcc/load_bearing_directories.md"
 echo ${MESSAGE} > lib/keep_load_bearing_directory
@@ -14,7 +14,7 @@ echo ${MESSAGE} > usr/lib/keep_load_bearing_directory
 # Package format: <target>-glibc-<version>-<date>.tar.xz
 # Example: x86_64-linux-gnu-glibc-2.28-20241130.tar.xz
 DATE=$(date +%Y%m%d)
-PACKAGE_NAME="x86_64-linux-gnu-glibc-${GLIBC_VERSION}-${DATE}.tar.xz"
+PACKAGE_NAME="${BUILD_ARCH}-linux-gnu-glibc-${GLIBC_VERSION}-${DATE}.tar.xz"
 
 XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
 

--- a/.github/workflows/build_glibc_aarch64.yml
+++ b/.github/workflows/build_glibc_aarch64.yml
@@ -1,0 +1,77 @@
+name: Build glibc (aarch64)
+
+on:
+  workflow_dispatch:
+    inputs:
+      glibc_versions:
+        description: 'JSON array of glibc versions (e.g., ["2.28", "2.39", "2.40"])'
+        required: true
+        default: '["2.28", "2.29", "2.30", "2.31", "2.32", "2.33", "2.34", "2.35", "2.36", "2.37", "2.38", "2.39", "2.40", "2.41", "2.42"]'
+        type: string
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_glibc
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  LINUX_VERSION: 6.18
+  TARGET: aarch64-linux-gnu
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        glibc_version: ${{ fromJson(github.event.inputs.glibc_versions) }}
+      fail-fast: false
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    env:
+      GLIBC_VERSION: ${{ matrix.glibc_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: ${{ env.SCRIPTS_DIR }}/step-1_install_dependencies
+
+      - name: Set up environment
+        run: ${{ env.SCRIPTS_DIR }}/environment
+
+      - name: Download glibc source
+        run: ${{ env.SCRIPTS_DIR }}/step-2.1_download_glibc_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download Linux kernel headers source
+        run: ${{ env.SCRIPTS_DIR }}/step-2.2_download_linux_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux kernel headers
+        run: ${{ env.SCRIPTS_DIR }}/step-3.1_install_linux_headers
+
+      - name: Install bootstrap gcc and binutils
+        run: ${{ env.SCRIPTS_DIR }}/step-3.2_install_gcc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build glibc
+        run: ${{ env.SCRIPTS_DIR }}/step-4_build_glibc
+
+      - name: Package glibc
+        run: ${{ env.SCRIPTS_DIR }}/step-5_package_glibc
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: ${{ env.SCRIPTS_DIR }}/step-6_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_glibc_x86_64.yml
+++ b/.github/workflows/build_glibc_x86_64.yml
@@ -1,4 +1,4 @@
-name: Build glibc
+name: Build glibc (x86_64)
 
 on:
   workflow_dispatch:
@@ -13,6 +13,7 @@ env:
   SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_glibc
   UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
   LINUX_VERSION: 6.18
+  TARGET: x86_64-linux-gnu
 
 jobs:
   build:


### PR DESCRIPTION
Problem
================================================================================

The glibc build workflow only supports x86_64, blocking the aarch64 toolchain chain (binutils → bootstrap GCC → glibc → full GCC).

Context
================================================================================

All architecture-specific values in the glibc build scripts are hardcoded to x86_64, preventing glibc from being built natively on aarch64.

What is hardcoded?
--------------------------------------------------------------------------------

- Linux kernel headers use ARCH=x86 instead of the target's kernel arch
- Bootstrap gcc/binutils tarball names use x86_64-linux-x86_64-bootstrap-*
- glibc configure uses x86_64-bootstrap-linux-gnu-gcc/ar/ranlib tool names
- --host=x86_64-linux-gnu is hardcoded in glibc configure
- -fcf-protection=none is passed unconditionally (x86-specific CET flag)
- Package name uses x86_64-linux-gnu prefix
- Dockerfile has no TARGET build arg
- Single workflow YAML targets x86_64 runners only

Solution
================================================================================

Parameterize all architecture-specific values using BUILD_ARCH and LINUX_ARCH derived from the TARGET variable, following the same pattern established in the binutils and GCC build scripts.

Changes:
- environment: add BUILD_ARCH=${TARGET%%-*} and LINUX_ARCH case mapping
- step-3.1: ARCH=x86 → ARCH=${LINUX_ARCH}
- step-3.2: hardcoded tarball prefixes → ${BUILD_ARCH}-linux-${BUILD_ARCH}-*
- step-4: tool names and --host use ${BUILD_ARCH}, CET flags conditional on x86_64
- step-5: package name uses ${BUILD_ARCH}
- Dockerfile: add ARG TARGET before build steps
- build.sh: accept TARGET as third argument
- Split workflow into build_glibc_x86_64.yml and build_glibc_aarch64.yml

Rationale
================================================================================

Why make -fcf-protection=none and --disable-cet conditional? --------------------------------------------------------------------------------

CET (Control-flow Enforcement Technology) is an x86-specific feature. The -fcf-protection flag is not recognized by aarch64 GCC and would cause a build error. The --disable-cet configure flag is similarly x86-specific.

Why derive BUILD_ARCH from TARGET instead of uname -m? --------------------------------------------------------------------------------

Only native builds are supported (aarch64-on-aarch64). Deriving from TARGET keeps the architecture source consistent with the rest of the build and avoids depending on host detection.