### PR TITLE
feat: add aarch64 support to musl build scripts

### DIFF
--- a/.github/workflows/build_musl/Dockerfile
+++ b/.github/workflows/build_musl/Dockerfile
@@ -18,6 +18,8 @@ COPY .github/workflows/utils/download_tarball ${UTILS_DIR}/download_tarball
 # ================
 # || Build musl ||
 # ================
+ARG TARGET=x86_64-linux-musl
+
 COPY .github/workflows/build_musl/step-1_install_dependencies ${SCRIPTS_DIR}/
 RUN ${SCRIPTS_DIR}/step-1_install_dependencies
 

--- a/.github/workflows/build_musl/build.sh
+++ b/.github/workflows/build_musl/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -euox pipefail
 
-# Usage: Run from repo root with GitHub token
-#   .github/workflows/build_musl/build.sh <MUSL_VERSION> <GH_TOKEN>
+# Usage: Run from repo root with musl version, target, and GitHub token
+#   .github/workflows/build_musl/build.sh <MUSL_VERSION> <TARGET> <GH_TOKEN>
+#   .github/workflows/build_musl/build.sh 1.2.5 aarch64-linux-musl <GH_TOKEN>
 
 docker build \
     -f .github/workflows/build_musl/Dockerfile \
-    --build-arg MUSL_VERSION=$1 \
-    --build-arg GH_TOKEN=$2 \
+    --build-arg MUSL_VERSION="${1}" \
+    --build-arg TARGET="${2}" \
+    --build-arg GH_TOKEN="${3}" \
     -t musl \
     .
 

--- a/.github/workflows/build_musl/environment
+++ b/.github/workflows/build_musl/environment
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euox pipefail
 
+export BUILD_ARCH=${TARGET%%-*}
+
+# Linux kernel ARCH values differ from GNU triplet arch names
+case ${BUILD_ARCH} in
+    x86_64)  export LINUX_ARCH="x86" ;;
+    aarch64) export LINUX_ARCH="arm64" ;;
+esac
+
 # ==============================
 # || Setup Source Directories ||
 # ==============================

--- a/.github/workflows/build_musl/step-2.3_download_binutils
+++ b/.github/workflows/build_musl/step-2.3_download_binutils
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
-${UTILS_DIR}/download_tarball "x86_64-linux-x86_64-bootstrap-linux-musl-binutils-2.45-" "${BUILD_TOOLS}"
+${UTILS_DIR}/download_tarball "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-musl-binutils-2.45-" "${BUILD_TOOLS}"

--- a/.github/workflows/build_musl/step-2.4_download_gcc
+++ b/.github/workflows/build_musl/step-2.4_download_gcc
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
-${UTILS_DIR}/download_tarball "x86_64-linux-x86_64-bootstrap-linux-musl-gcc-15.2.0-" "${BUILD_TOOLS}"
+${UTILS_DIR}/download_tarball "${BUILD_ARCH}-linux-${BUILD_ARCH}-bootstrap-linux-musl-gcc-15.2.0-" "${BUILD_TOOLS}"

--- a/.github/workflows/build_musl/step-3_install_linux_headers
+++ b/.github/workflows/build_musl/step-3_install_linux_headers
@@ -8,9 +8,9 @@ cd ${LINUX_BUILD}
 
 make -C ${LINUX_SOURCE} \
     HOSTCC=gcc \
-    CROSS_COMPILE=x86_64-linux-musl- \
+    CROSS_COMPILE=${BUILD_ARCH}-linux-musl- \
     O=${LINUX_BUILD} \
-    ARCH=x86 \
+    ARCH=${LINUX_ARCH} \
     INSTALL_HDR_PATH=${BUILD_TOOLS}/usr \
     V=0 \
     headers_install

--- a/.github/workflows/build_musl/step-4_build_musl
+++ b/.github/workflows/build_musl/step-4_build_musl
@@ -8,10 +8,10 @@ MUSL_BUILD="/tmp/musl-build"
 mkdir -p ${MUSL_BUILD}
 cd ${MUSL_BUILD}
 
-env CROSS_COMPILE=x86_64-bootstrap-linux-musl- \
+env CROSS_COMPILE=${BUILD_ARCH}-bootstrap-linux-musl- \
     ${MUSL_SOURCE}/configure \
-        --host=x86_64-bootstrap-linux-musl \
-        --target=x86_64-linux-musl \
+        --host=${BUILD_ARCH}-bootstrap-linux-musl \
+        --target=${BUILD_ARCH}-linux-musl \
         --prefix=/usr \
         --libdir=/usr/lib \
         --disable-gcc-wrapper \

--- a/.github/workflows/build_musl/step-5_package_musl
+++ b/.github/workflows/build_musl/step-5_package_musl
@@ -5,4 +5,4 @@ source ${SCRIPTS_DIR}/environment
 DATE=$(date +%Y%m%d)
 
 cd "${MUSL_ARTIFACTS}"
-XZ_OPT=-e9 tar -cJf "${ARTIFACTS_DIR}/x86_64-linux-musl-musl-${MUSL_VERSION}-${DATE}.tar.xz" *
+XZ_OPT=-e9 tar -cJf "${ARTIFACTS_DIR}/${BUILD_ARCH}-linux-musl-musl-${MUSL_VERSION}-${DATE}.tar.xz" *

--- a/.github/workflows/build_musl_aarch64.yml
+++ b/.github/workflows/build_musl_aarch64.yml
@@ -1,0 +1,77 @@
+name: Build musl libc (aarch64)
+
+on:
+  workflow_dispatch:
+    inputs:
+      musl_version:
+        description: 'musl version to build'
+        required: true
+        default: '1.2.5'
+        type: string
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_musl
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  MUSL_VERSION: ${{ github.event.inputs.musl_version }}
+  TARGET: aarch64-linux-musl
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: ${{ env.SCRIPTS_DIR }}/step-1_install_dependencies
+
+      - name: Set up environment
+        run: ${{ env.SCRIPTS_DIR }}/environment
+
+      - name: Download Linux kernel source
+        run: ${{ env.SCRIPTS_DIR }}/step-2.1_download_linux_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download musl source
+        run: ${{ env.SCRIPTS_DIR }}/step-2.2_download_musl_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download pre-built binutils
+        run: ${{ env.SCRIPTS_DIR }}/step-2.3_download_binutils
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download pre-built GCC
+        run: ${{ env.SCRIPTS_DIR }}/step-2.4_download_gcc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux kernel headers
+        run: ${{ env.SCRIPTS_DIR }}/step-3_install_linux_headers
+
+      - name: Build musl
+        run: ${{ env.SCRIPTS_DIR }}/step-4_build_musl
+
+      - name: Package musl
+        run: ${{ env.SCRIPTS_DIR }}/step-5_package_musl
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: ${{ env.SCRIPTS_DIR }}/step-6_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_musl_x86_64.yml
+++ b/.github/workflows/build_musl_x86_64.yml
@@ -1,4 +1,4 @@
-name: Build musl libc
+name: Build musl libc (x86_64)
 
 on:
   workflow_dispatch:
@@ -20,6 +20,7 @@ env:
   SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_musl
   UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
   MUSL_VERSION: ${{ github.event.inputs.musl_version }}
+  TARGET: x86_64-linux-musl
 
 jobs:
   build:


### PR DESCRIPTION
Problem
================================================================================

The musl build workflow only supports x86_64, blocking the aarch64 musl toolchain chain (binutils → bootstrap GCC → musl → full GCC).

Context
================================================================================

All architecture-specific values in the musl build scripts are hardcoded to x86_64, preventing musl from being built natively on aarch64.

What is hardcoded?
--------------------------------------------------------------------------------

- Bootstrap binutils tarball name uses x86_64-linux-x86_64-bootstrap-linux-musl-*
- Bootstrap GCC tarball name uses x86_64-linux-x86_64-bootstrap-linux-musl-*
- Linux kernel headers use CROSS_COMPILE=x86_64-linux-musl- and ARCH=x86
- musl configure uses CROSS_COMPILE=x86_64-bootstrap-linux-musl-, --host=x86_64-bootstrap-linux-musl, --target=x86_64-linux-musl
- Package name uses x86_64-linux-musl prefix
- Dockerfile has no TARGET build arg
- Single workflow YAML targets x86_64 runners only

Solution
================================================================================

Parameterize all architecture-specific values using BUILD_ARCH and LINUX_ARCH derived from the TARGET variable, following the same pattern established in the binutils, GCC, and glibc build scripts.

Changes:
- environment: add BUILD_ARCH=${TARGET%%-*} and LINUX_ARCH case mapping
- step-2.3/2.4: tarball prefixes use ${BUILD_ARCH}
- step-3: CROSS_COMPILE and ARCH use ${BUILD_ARCH} and ${LINUX_ARCH}
- step-4: CROSS_COMPILE, --host, --target use ${BUILD_ARCH}
- step-5: package name uses ${BUILD_ARCH}
- Dockerfile: add ARG TARGET before build steps
- build.sh: accept TARGET as second argument
- Split workflow into build_musl_x86_64.yml and build_musl_aarch64.yml

Rationale
================================================================================

Why is musl simpler than glibc?
--------------------------------------------------------------------------------

Unlike glibc which required conditional handling of x86-specific CET flags (-fcf-protection=none, --disable-cet), musl has no architecture-specific compiler flags. The changes are a straightforward parameterization of hardcoded x86_64 values.

Why derive BUILD_ARCH from TARGET instead of uname -m? --------------------------------------------------------------------------------

Only native builds are supported (aarch64-on-aarch64). Deriving from TARGET keeps the architecture source consistent with the rest of the build and avoids depending on host detection.