### PR TITLE
feat: add aarch64 support to linux headers build scripts

### DIFF
--- a/.github/workflows/build_linux_headers/Dockerfile
+++ b/.github/workflows/build_linux_headers/Dockerfile
@@ -20,6 +20,8 @@ COPY .github/workflows/utils/download_tarball $UTILS_DIR/
 # =========================
 # || Build Linux headers ||
 # =========================
+ARG TARGET=x86_64-linux
+
 COPY .github/workflows/build_linux_headers/step-1_install_dependencies $SCRIPTS_DIR/
 RUN $SCRIPTS_DIR/step-1_install_dependencies
 

--- a/.github/workflows/build_linux_headers/build.sh
+++ b/.github/workflows/build_linux_headers/build.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -euox pipefail
 
-# Usage: Run from repo root with GitHub token
-#   .github/workflows/build_linux_headers/build.sh <LINUX_VERSION> <GH_TOKEN>
-#   .github/workflows/build_linux_headers/build.sh 6.18 <GH_TOKEN>
+# Usage: Run from repo root with Linux version, target, and GitHub token
+#   .github/workflows/build_linux_headers/build.sh <LINUX_VERSION> <TARGET> <GH_TOKEN>
+#   .github/workflows/build_linux_headers/build.sh 6.18 aarch64-linux <GH_TOKEN>
 
 docker build \
     -f .github/workflows/build_linux_headers/Dockerfile \
-    --build-arg LINUX_VERSION=$1 \
-    --build-arg GH_TOKEN=$2 \
+    --build-arg LINUX_VERSION="${1}" \
+    --build-arg TARGET="${2}" \
+    --build-arg GH_TOKEN="${3}" \
     -t linux-headers \
     .
 

--- a/.github/workflows/build_linux_headers/environment
+++ b/.github/workflows/build_linux_headers/environment
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euox pipefail
 
+export BUILD_ARCH=${TARGET%%-*}
+
+# Linux kernel ARCH values differ from GNU triplet arch names
+case ${BUILD_ARCH} in
+    x86_64)  export LINUX_ARCH="x86" ;;
+    aarch64) export LINUX_ARCH="arm64" ;;
+esac
+
 export SYSROOT_DIR="/tmp/sysroot"
 export ARTIFACTS_DIR="/tmp/artifacts"
 export LINUX_SOURCE="/tmp/linux-source"

--- a/.github/workflows/build_linux_headers/step-3_install_linux_headers
+++ b/.github/workflows/build_linux_headers/step-3_install_linux_headers
@@ -10,7 +10,7 @@ pushd "${LINUX_SOURCE}"
 make \
     "HOSTCC=gcc" \
     "O=${LINUX_BUILD_DIR}" \
-    "ARCH=x86" \
+    "ARCH=${LINUX_ARCH}" \
     "INSTALL_HDR_PATH=${SYSROOT_DIR}/usr" \
     "V=0" \
     headers_install

--- a/.github/workflows/build_linux_headers/step-4_package_linux_headers
+++ b/.github/workflows/build_linux_headers/step-4_package_linux_headers
@@ -5,7 +5,7 @@ source ${SCRIPTS_DIR}/environment
 pushd "${SYSROOT_DIR}"
 
 DATE=$(date +%Y%m%d)
-PACKAGE_NAME="x86_64-linux-headers-${LINUX_VERSION}-${DATE}.tar.xz"
+PACKAGE_NAME="${BUILD_ARCH}-linux-headers-${LINUX_VERSION}-${DATE}.tar.xz"
 
 XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${PACKAGE_NAME}" *
 

--- a/.github/workflows/build_linux_headers_aarch64.yml
+++ b/.github/workflows/build_linux_headers_aarch64.yml
@@ -1,4 +1,4 @@
-name: Build Linux headers
+name: Build Linux headers (aarch64)
 
 on:
   workflow_dispatch:
@@ -12,10 +12,11 @@ on:
 env:
   SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_linux_headers
   UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  TARGET: aarch64-linux
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         linux_version: ${{ fromJson(github.event.inputs.linux_versions) }}

--- a/.github/workflows/build_linux_headers_x86_64.yml
+++ b/.github/workflows/build_linux_headers_x86_64.yml
@@ -1,0 +1,63 @@
+name: Build Linux headers (x86_64)
+
+on:
+  workflow_dispatch:
+    inputs:
+      linux_versions:
+        description: 'JSON array of Linux versions (e.g., ["6.18"])'
+        required: true
+        default: '["6.18"]'
+        type: string
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_linux_headers
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  TARGET: x86_64-linux
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        linux_version: ${{ fromJson(github.event.inputs.linux_versions) }}
+      fail-fast: false
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    env:
+      LINUX_VERSION: ${{ matrix.linux_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: ${{ env.SCRIPTS_DIR }}/step-1_install_dependencies
+
+      - name: Set up environment
+        run: ${{ env.SCRIPTS_DIR }}/environment
+
+      - name: Download Linux kernel source
+        run: ${{ env.SCRIPTS_DIR }}/step-2_download_linux_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux kernel headers
+        run: ${{ env.SCRIPTS_DIR }}/step-3_install_linux_headers
+
+      - name: Package Linux kernel headers
+        run: ${{ env.SCRIPTS_DIR }}/step-4_package_linux_headers
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: ${{ env.SCRIPTS_DIR }}/step-5_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Problem
================================================================================

The linux headers build workflow only produces x86_64 headers, blocking the aarch64 toolchain from being fully usable in toolchains_cc.

Context
================================================================================

All other toolchain components (binutils, GCC, glibc, musl) have been parameterized for aarch64 and their artifacts built, but linux headers still has hardcoded x86_64 references.

What functionality is missing?
--------------------------------------------------------------------------------

Linux kernel headers are architecture-specific (ARCH=x86 vs ARCH=arm64). Without aarch64 headers, the aarch64 toolchain cannot be registered in Bazel's download configuration.

Solution
================================================================================

Parameterize the linux headers build scripts for architecture, following the same pattern used in the binutils, GCC, glibc, and musl workflows:

- Add BUILD_ARCH and LINUX_ARCH to environment (derived from TARGET)
- Replace hardcoded ARCH=x86 with ARCH=${LINUX_ARCH}
- Parameterize package name to use ${BUILD_ARCH}
- Add ARG TARGET to Dockerfile
- Accept TARGET as build.sh argument
- Split single workflow into per-architecture files (x86_64 + aarch64)

Rationale
================================================================================

Why the same pattern as other workflows?
--------------------------------------------------------------------------------

Consistency across all build workflows makes them easier to maintain and reason about. Every workflow now derives BUILD_ARCH from TARGET using the same ${TARGET%%-*} parameter expansion.

Why split into separate workflow files?
--------------------------------------------------------------------------------

GitHub Actions does not support per-architecture runner selection within a single workflow matrix. aarch64 requires ubuntu-24.04-arm runners while x86_64 uses ubuntu-latest.