### PR TITLE
feat: add aarch64-linux-gnu toolchain support to Bazel configuration

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "MHumC4HkcubC2XqhdgmDOpNhI4IRrc3uXY2oyPCTC14=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/docs/runbooks/add-toolchain-configuration.md
+++ b/docs/runbooks/add-toolchain-configuration.md
@@ -4,120 +4,106 @@ This runbook describes the complete process for adding a new toolchain configura
 
 ## Overview
 
-Toolchains are defined by three parameters:
-- **Target triple**: e.g., `x86_64-linux-gnu`, `x86_64-linux-musl`
-- **libc version**: glibc (e.g., `2.28` to `2.42`) or musl (e.g., `1.2.5`)
-- **Compiler version**: GCC version (e.g., `14.3.0`, `15.2.0`)
+Toolchains are defined by these parameters:
+- **Target triple**: e.g., `x86_64-linux-gnu`, `aarch64-linux-gnu`, `x86_64-linux-musl`
+- **libc version**: glibc (e.g., `2.28`) or musl (e.g., `1.2.5`)
+- **Compiler version**: GCC version (e.g., `15.2.0`) or LLVM version (e.g., `21.1.1`)
+
+The host platform is derived from the target triple (only native builds are supported).
 
 ## Prerequisites
 
 Before adding a new configuration:
-- [ ] Verify the toolchain binaries have been built and published as a GitHub release
-- [ ] Have the release URL available
-- [ ] Have the SHA256 hash of the tarball ready
+- [ ] Verify the toolchain binaries have been built and published to the [`binaries` GitHub release](https://github.com/reutermj/toolchains_cc/releases/tag/binaries)
+- [ ] Have the SHA256 hashes of all required tarballs ready
 
 ## Step-by-step Procedure
 
-### 1. Update Support Matrix
+### 1. Update Supported Versions
 
-Edit [private/config.bzl](../../private/config.bzl) and add an entry to the `SUPPORT_MATRIX` dictionary.
+Edit [private/config.bzl](../../private/config.bzl) and add entries to the `SUPPORTED_VERSIONS` dictionary.
 
-**Location**: Find the `SUPPORT_MATRIX` dictionary (around line 50+)
+Add the new value to the appropriate key (e.g., `"target"`, `"libc_version"`, `"compiler_version"`):
 
-**Format**:
 ```python
-SUPPORT_MATRIX = {
-    # ... existing entries ...
-    "x86_64-linux-gnu:2.42:gcc:15.2.0": struct(
-        target = "x86_64-linux-gnu",
-        libc = "glibc",
-        libc_version = "2.42",
-        compiler = "gcc",
-        compiler_version = "15.2.0",
-    ),
+SUPPORTED_VERSIONS = {
+    "target": {
+        "x86_64-linux-gnu": True,
+        "aarch64-linux-gnu": True,  # <-- new target
+    },
+    # ... other keys ...
 }
 ```
 
-**Key format**: `{target}:{libc_version}:{compiler}:{compiler_version}`
+### 2. Add Release Metadata to Download Files
 
-### 2. Add Release Date
+Each component has its own file in [private/downloads/](../../private/downloads/):
 
-Edit [private/download_bins.bzl](../../private/download_bins.bzl) and add the release date mapping.
+| Component     | File                                                              |
+|---------------|-------------------------------------------------------------------|
+| GCC           | [private/downloads/gcc.bzl](../../private/downloads/gcc.bzl)           |
+| glibc         | [private/downloads/glibc.bzl](../../private/downloads/glibc.bzl)       |
+| musl          | [private/downloads/musl.bzl](../../private/downloads/musl.bzl)         |
+| binutils      | [private/downloads/binutils.bzl](../../private/downloads/binutils.bzl) |
+| Linux headers | [private/downloads/linux_headers.bzl](../../private/downloads/linux_headers.bzl) |
+| LLVM          | [private/downloads/llvm.bzl](../../private/downloads/llvm.bzl)         |
 
-**Location**: Find the `RELEASE_TO_DATE` dictionary
+For each affected component, add entries to both `RELEASE_TO_DATE` and `TARBALL_TO_SHA256`. See the [update-binary-release-metadata runbook](update-binary-release-metadata.md) for the exact key formats and procedure.
 
-**Format**:
+### 3. Update Platform Constraints (if adding a new architecture)
+
+If this is a new CPU architecture (not just a new version), update [private/declare_toolchain.bzl](../../private/declare_toolchain.bzl):
+
+Add the architecture to `_TARGET_TO_CPU_CONSTRAINT`:
+
 ```python
-RELEASE_TO_DATE = {
-    # ... existing entries ...
-    "x86_64-linux-gnu-glibc-2.42-gcc-15.2.0": "2024-01-15",
+_TARGET_TO_CPU_CONSTRAINT = {
+    "x86_64": "@platforms//cpu:x86_64",
+    "aarch64": "@platforms//cpu:aarch64",
 }
 ```
-
-**Key format**: `{target}-{libc}-{libc_version}-{compiler}-{compiler_version}`
-
-### 3. Add SHA256 Hash
-
-In the same file [private/download_bins.bzl](../../private/download_bins.bzl), add the SHA256 hash.
-
-**Location**: Find the `TARBALL_TO_SHA256` dictionary
-
-**Format**:
-```python
-TARBALL_TO_SHA256 = {
-    # ... existing entries ...
-    "x86_64-linux-gnu-glibc-2.42-gcc-15.2.0.tar.zst": "abc123def456...",
-}
-```
-
-**Key format**: `{target}-{libc}-{libc_version}-{compiler}-{compiler_version}.tar.zst`
 
 **Getting the SHA256 hash**:
 ```bash
-# If you have the tarball locally
-sha256sum x86_64-linux-gnu-glibc-2.42-gcc-15.2.0.tar.zst
+# Download from GitHub release
+gh release download binaries \
+  --pattern "<tarball-name>" \
+  --dir /tmp/release-artifacts
 
-# Or from GitHub releases
-curl -sL https://github.com/beadss/toolchains_cc/releases/download/... | sha256sum
+# Compute the SHA256 hash
+sha256sum /tmp/release-artifacts/<tarball-name>
 ```
 
 ## Testing the New Configuration
 
-After making the changes:
+Each example is its own Bazel module. The `repo_env` flag format is `{toolchain_name}_{var_name}`, where the toolchain name comes from the `cc_toolchains.declare(name = ...)` tag in each example's `MODULE.bazel`. The examples all use `name = "my_toolchain"`.
 
 ```bash
-# Test building with the new configuration
-./bazel build \
-  --repo_env=toolchains_cc_target=x86_64-linux-gnu \
-  --repo_env=toolchains_cc_libc_version=2.42 \
-  --repo_env=toolchains_cc_compiler_version=15.2.0 \
-  //tests/...
-
-# Run tests
-./bazel test \
-  --repo_env=toolchains_cc_target=x86_64-linux-gnu \
-  --repo_env=toolchains_cc_libc_version=2.42 \
-  --repo_env=toolchains_cc_compiler_version=15.2.0 \
-  //tests/...
+for example in examples/*/; do
+  (cd "$example" && bazel build \
+    --repo_env=my_toolchain_target=<target> \
+    --repo_env=my_toolchain_libc_version=<libc_version> \
+    --repo_env=my_toolchain_compiler_version=<compiler_version> \
+    //...)
+done
 ```
-
-## Updating CI
-
-If this is a new configuration that should be tested in CI, update [.github/workflows/ci.yml](../../.github/workflows/ci.yml) to include it in the test matrix.
 
 ## Common Issues
 
-### Issue: "Unsupported configuration"
-**Solution**: Verify the key format exactly matches in all three locations (SUPPORT_MATRIX, RELEASE_TO_DATE, TARBALL_TO_SHA256)
+### Issue: "Unsupported {key}={value}"
+**Solution**: Verify the value is added to `SUPPORTED_VERSIONS` in [private/config.bzl](../../private/config.bzl).
+
+### Issue: Key not found in `RELEASE_TO_DATE`
+**Solution**: Verify the key format matches exactly. Check the download function in the relevant `.bzl` file to see the expected key format.
 
 ### Issue: "SHA256 mismatch"
 **Solution**: Re-download the tarball and recalculate the hash. Ensure you're using the correct release.
 
-### Issue: "Release not found"
-**Solution**: Verify the release exists on GitHub and the URL pattern in download_bins.bzl is correct.
-
 ## Related Files
 
-- [private/config.bzl](../../private/config.bzl): Configuration validation and support matrix
-- [private/download_bins.bzl](../../private/download_bins.bzl): Release URLs and hashes
-- [private/lazy_download_bins.bzl](../../private/lazy_download_bins.bzl): Download logic
+- [private/config.bzl](../../private/config.bzl): Configuration validation and supported versions
+- [private/downloads/](../../private/downloads/): Individual download files per component
+- [private/downloads/constants.bzl](../../private/downloads/constants.bzl): Base URL and `get_host` helper
+- [private/declare_toolchain.bzl](../../private/declare_toolchain.bzl): Toolchain declaration with platform constraints
+- [private/eager_declare_toolchain.bzl](../../private/eager_declare_toolchain.bzl): Eagerly declares toolchain metadata
+- [private/lazy_download_bins.bzl](../../private/lazy_download_bins.bzl): Lazily downloads binaries when needed

--- a/examples/boost/MODULE.bazel.lock
+++ b/examples/boost/MODULE.bazel.lock
@@ -335,7 +335,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "t07dFfXroD/Px6unuqd0UIInaJh0Ed03/8uqe2zWhq0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/curl/MODULE.bazel.lock
+++ b/examples/curl/MODULE.bazel.lock
@@ -227,7 +227,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "ytOVRzGgux6+Z+puB7pVw5IBB5VkOHhdx8hQvfCdrNQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/fmt/MODULE.bazel.lock
+++ b/examples/fmt/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "Ogym/dCmE+yG3VjrEigpE5oYAo3HhD1gn3BPgweOWyg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/googletest/MODULE.bazel.lock
+++ b/examples/googletest/MODULE.bazel.lock
@@ -280,7 +280,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "zF9BFQevLFjrq1Y9IIpx6f93/ZXqI7e2NkgYy5deUHs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/sqlite/MODULE.bazel.lock
+++ b/examples/sqlite/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "hmLP2+eWOtQrYKPXKM2vUUap6waUis9xTl4GTYjHe5I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/zlib/MODULE.bazel.lock
+++ b/examples/zlib/MODULE.bazel.lock
@@ -206,7 +206,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "KLh+0S9/jJzkEYXFDdXEVdFfBDFttBOGRsxrdxZmJ1s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/zstd/MODULE.bazel.lock
+++ b/examples/zstd/MODULE.bazel.lock
@@ -208,7 +208,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5SItW0gEJF/99c4Md2dfeShJeiXhetHrA3vLQy/HtI4=",
+        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
         "usagesDigest": "NRFDpWlXnA3yL2SDjG9Iaxpylu88xhp3HdOgPna5/pA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -88,6 +88,7 @@ SUPPORTED_VERSIONS = {
     "target": {
         "x86_64-linux-gnu": True,
         "x86_64-linux-musl": True,
+        "aarch64-linux-gnu": True,
     },
     "libc_version": {
         "1.2.5": True,

--- a/private/declare_toolchain.bzl
+++ b/private/declare_toolchain.bzl
@@ -3,7 +3,12 @@
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 
-def declare_toolchain(name, visibility, sysroot, all_tools, compiler):
+_TARGET_TO_CPU_CONSTRAINT = {
+    "x86_64": "@platforms//cpu:x86_64",
+    "aarch64": "@platforms//cpu:aarch64",
+}
+
+def declare_toolchain(name, visibility, sysroot, all_tools, compiler, target):
     """Declares a cc_toolchain with the given parameters.
 
     Args:
@@ -12,6 +17,7 @@ def declare_toolchain(name, visibility, sysroot, all_tools, compiler):
         sysroot: Label for the sysroot subdirectory target
         all_tools: Tool map for the toolchain
         compiler: Compiler type
+        target: Target triple (e.g., x86_64-linux-gnu, aarch64-linux-gnu)
     """
     args = []
     # ==================================
@@ -103,15 +109,18 @@ def declare_toolchain(name, visibility, sysroot, all_tools, compiler):
     # =======================
     # || Declare Toolchain ||
     # =======================
+    arch = target.split("-")[0]
+    cpu_constraint = _TARGET_TO_CPU_CONSTRAINT[arch]
+
     native.toolchain(
         name = name,
         exec_compatible_with = [
             "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
+            cpu_constraint,
         ],
         target_compatible_with = [
             "@platforms//os:linux",
-            "@platforms//cpu:x86_64",
+            cpu_constraint,
         ],
         toolchain = ":{}_cc_toolchain".format(name),
         toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",

--- a/private/downloads/binutils.bzl
+++ b/private/downloads/binutils.bzl
@@ -1,6 +1,6 @@
 """Functions for downloading binutils binaries."""
 
-load(":constants.bzl", "DOWNLOAD_BASE_URL")
+load(":constants.bzl", "DOWNLOAD_BASE_URL", "get_host")
 
 visibility("//private/...")
 
@@ -12,14 +12,17 @@ def download_binutils(rctx, config):
       config: The configuration dictionary.
     """
 
-    binutils_bins_name = "x86_64-linux-{target}-binutils-{binutils_version}".format(
+    host = get_host(config)
+
+    binutils_bins_name = "{host}-{target}-binutils-{binutils_version}".format(
+        host = host,
         binutils_version = config["binutils_version"],
         target = config["target"],
     )
     binutils_date = RELEASE_TO_DATE[binutils_bins_name]
 
-    # TODO: update to use {host}
-    binutils_tarball_name = "x86_64-linux-{target}-binutils-{binutils_version}-{binutils_date}.tar.xz".format(
+    binutils_tarball_name = "{host}-{target}-binutils-{binutils_version}-{binutils_date}.tar.xz".format(
+        host = host,
         binutils_version = config["binutils_version"],
         target = config["target"],
         binutils_date = binutils_date,
@@ -36,9 +39,11 @@ def download_binutils(rctx, config):
 RELEASE_TO_DATE = {
     "x86_64-linux-x86_64-linux-gnu-binutils-2.45": "20260218",
     "x86_64-linux-x86_64-linux-musl-binutils-2.45": "20260219",
+    "aarch64-linux-aarch64-linux-gnu-binutils-2.45": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
     "x86_64-linux-x86_64-linux-gnu-binutils-2.45-20260218.tar.xz": "c1f56ffbadc36fc5b74f969e27e6eeca770d62286135f5a1b9ce044cf09135c3",
     "x86_64-linux-x86_64-linux-musl-binutils-2.45-20260219.tar.xz": "b68e2adae65d6eb22fbeb161acca652cae6eb5413581bcfa953072e1bbf9d79b",
+    "aarch64-linux-aarch64-linux-gnu-binutils-2.45-20260228.tar.xz": "a0ec2a34a8f084911c747543b0dd54c62759990b46ea022e67a9c2c8c5a48e61",
 }

--- a/private/downloads/constants.bzl
+++ b/private/downloads/constants.bzl
@@ -3,3 +3,19 @@
 visibility("//private/...")
 
 DOWNLOAD_BASE_URL = "https://github.com/reutermj/toolchains_cc/releases/download/binaries"
+
+def get_host(config):
+    """Derive the host platform prefix from the target triple.
+
+    Only native builds are supported (host arch == target arch), so the host
+    is derived directly from the target triple.
+
+    Args:
+        config: The configuration dictionary containing "target".
+
+    Returns:
+        The host platform prefix (e.g., "x86_64-linux", "aarch64-linux").
+    """
+    target = config["target"]
+    arch = target.split("-")[0]
+    return "{}-linux".format(arch)

--- a/private/downloads/gcc.bzl
+++ b/private/downloads/gcc.bzl
@@ -1,6 +1,6 @@
 """Functions for downloading GCC binaries and libraries."""
 
-load(":constants.bzl", "DOWNLOAD_BASE_URL")
+load(":constants.bzl", "DOWNLOAD_BASE_URL", "get_host")
 
 visibility("//private/...")
 
@@ -12,21 +12,22 @@ def download_gcc(rctx, config):
       config: The configuration dictionary.
     """
 
-    # TODO: update to use {host}
-    gcc_bins_name = "x86_64-linux-{target}-gcc-{compiler_version}".format(
+    host = get_host(config)
+
+    gcc_bins_name = "{host}-{target}-gcc-{compiler_version}".format(
+        host = host,
         compiler_version = config["compiler_version"],
         target = config["target"],
     )
     gcc_date = RELEASE_TO_DATE[gcc_bins_name]
 
-    # TODO: update to use {host}
-    gcc_bins_tarball_name = "x86_64-linux-{target}-gcc-{compiler_version}-{gcc_date}.tar.xz".format(
+    gcc_bins_tarball_name = "{host}-{target}-gcc-{compiler_version}-{gcc_date}.tar.xz".format(
+        host = host,
         compiler_version = config["compiler_version"],
         target = config["target"],
         gcc_date = gcc_date,
     )
 
-    # TODO: update to use {host}
     gcc_libs_tarball_name = "{target}-gcc-lib-{compiler_version}-{gcc_date}.tar.xz".format(
         compiler_version = config["compiler_version"],
         target = config["target"],
@@ -52,6 +53,7 @@ def download_gcc(rctx, config):
 RELEASE_TO_DATE = {
     "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260222",
     "x86_64-linux-x86_64-linux-musl-gcc-15.2.0": "20260222",
+    "aarch64-linux-aarch64-linux-gnu-gcc-15.2.0": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
@@ -59,4 +61,6 @@ TARBALL_TO_SHA256 = {
     "x86_64-linux-gnu-gcc-lib-15.2.0-20260222.tar.xz": "372c953c9cd8455b2fc541b33ad790622665efc17b4bf128f52f4844c9c6ed1e",
     "x86_64-linux-x86_64-linux-musl-gcc-15.2.0-20260222.tar.xz": "940c7e9f4bf88838eb2497f1073b203877c86dc8efae5fc6311dc5e517ec6c56",
     "x86_64-linux-musl-gcc-lib-15.2.0-20260222.tar.xz": "90e1049836ff83ae44e6c7cb0cd14d83913ea5963516e9131ed46dfc1e44d3e9",
+    "aarch64-linux-aarch64-linux-gnu-gcc-15.2.0-20260228.tar.xz": "56103e50a905906ea78b0a4e291b4c3fb92b2a182cc3b185b55229d3323b219a",
+    "aarch64-linux-gnu-gcc-lib-15.2.0-20260228.tar.xz": "93951d47eb9aa4d31e0167ab015d98b688d919659577573fae636ddb3c806559",
 }

--- a/private/downloads/glibc.bzl
+++ b/private/downloads/glibc.bzl
@@ -18,7 +18,6 @@ def download_glibc(rctx, config):
     )
     glibc_date = RELEASE_TO_DATE[glibc_bins_name]
 
-    # TODO: update to use {host}
     glibc_tarball_name = "{target}-glibc-{glibc_version}-{glibc_date}.tar.xz".format(
         glibc_version = config["libc_version"],
         target = config["target"],
@@ -35,8 +34,10 @@ def download_glibc(rctx, config):
 
 RELEASE_TO_DATE = {
     "x86_64-linux-gnu-glibc-2.28": "20260218",
+    "aarch64-linux-gnu-glibc-2.28": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
     "x86_64-linux-gnu-glibc-2.28-20260218.tar.xz": "c808d0145434c9fbb273662712c212b99489489396a09b50faa84212f070a9e7",
+    "aarch64-linux-gnu-glibc-2.28-20260228.tar.xz": "28a46420f38d2f975544f24ee70cedd45c698abed32e567eaa60db0eeb4364b0",
 }

--- a/private/downloads/linux_headers.bzl
+++ b/private/downloads/linux_headers.bzl
@@ -1,6 +1,6 @@
 """Functions for downloading Linux kernel headers."""
 
-load(":constants.bzl", "DOWNLOAD_BASE_URL")
+load(":constants.bzl", "DOWNLOAD_BASE_URL", "get_host")
 
 visibility("//private/...")
 
@@ -12,13 +12,17 @@ def download_linux_headers(rctx, config):
       config: The configuration dictionary.
     """
 
-    linux_headers_name = "x86_64-linux-headers-{linux_headers_version}".format(
+    host = get_host(config)
+    arch = host.split("-")[0]
+
+    linux_headers_name = "{arch}-linux-headers-{linux_headers_version}".format(
+        arch = arch,
         linux_headers_version = config["linux_headers_version"],
     )
     linux_headers_date = RELEASE_TO_DATE[linux_headers_name]
 
-    # TODO: update to use {host}
-    linux_headers_tarball_name = "x86_64-linux-headers-{linux_headers_version}-{linux_headers_date}.tar.xz".format(
+    linux_headers_tarball_name = "{arch}-linux-headers-{linux_headers_version}-{linux_headers_date}.tar.xz".format(
+        arch = arch,
         linux_headers_version = config["linux_headers_version"],
         linux_headers_date = linux_headers_date,
     )
@@ -33,8 +37,10 @@ def download_linux_headers(rctx, config):
 
 RELEASE_TO_DATE = {
     "x86_64-linux-headers-6.18": "20260217",
+    "aarch64-linux-headers-6.18": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
     "x86_64-linux-headers-6.18-20260217.tar.xz": "34396267a578ef4b81b3951b826c236cf385f7f008bb20b348731ca3318b7c6f",
+    "aarch64-linux-headers-6.18-20260228.tar.xz": "dafd326fe1df8fce64805b420666606f984a76087563e36c4ff69cb5e323751a",
 }

--- a/private/downloads/llvm.bzl
+++ b/private/downloads/llvm.bzl
@@ -1,6 +1,6 @@
 """Functions for downloading LLVM and libclang binaries."""
 
-load(":constants.bzl", "DOWNLOAD_BASE_URL")
+load(":constants.bzl", "DOWNLOAD_BASE_URL", "get_host")
 
 visibility("//private/...")
 
@@ -12,20 +12,22 @@ def download_llvm(rctx, config):
       config: The configuration dictionary.
     """
 
-    # TODO: update to use {host}
-    llvm_bins_name = "x86_64-linux-llvm-{compiler_version}".format(
+    host = get_host(config)
+
+    llvm_bins_name = "{host}-llvm-{compiler_version}".format(
+        host = host,
         compiler_version = config["compiler_version"],
     )
     llvm_date = RELEASE_TO_DATE[llvm_bins_name]
 
-    # TODO: update to use {host}
-    llvm_bins_tarball_name = "x86_64-linux-llvm-{compiler_version}-{llvm_date}.tar.xz".format(
+    llvm_bins_tarball_name = "{host}-llvm-{compiler_version}-{llvm_date}.tar.xz".format(
+        host = host,
         compiler_version = config["compiler_version"],
         llvm_date = llvm_date,
     )
 
-    # TODO: update to use {host}
-    libclang_tarball_name = "x86_64-linux-libclang-{compiler_version}-{llvm_date}.tar.xz".format(
+    libclang_tarball_name = "{host}-libclang-{compiler_version}-{llvm_date}.tar.xz".format(
+        host = host,
         compiler_version = config["compiler_version"],
         llvm_date = llvm_date,
     )

--- a/private/eager_declare_toolchain.bzl
+++ b/private/eager_declare_toolchain.bzl
@@ -15,12 +15,14 @@ declare_toolchain(
     sysroot = "@@{bins_repo_name}//:{original_name}_bins_sysroot",
     all_tools = "@@{bins_repo_name}//:{original_name}_bins_all_tools",
     compiler = "{compiler}",
+    target = "{target}",
     visibility = ["//visibility:public"],
 )
 """.lstrip().format(
             original_name = rctx.original_name,
             bins_repo_name = rctx.name + "_bins",
             compiler = config["compiler"],
+            target = config["target"],
         ),
     )
 


### PR DESCRIPTION
Problem
================================================================================

The toolchain can only be used on x86_64 hosts. Users on aarch64 machines cannot use toolchains_cc to compile C/C++ code natively.

Context
================================================================================

All aarch64 build artifacts (GCC, binutils, glibc, linux headers) have been built and published to the binaries GitHub release, but the Bazel download and configuration layer has no way to use them.

What functionality is missing?
--------------------------------------------------------------------------------

The download .bzl files hardcode "x86_64-linux" as the host platform prefix in tarball names. The SUPPORTED_VERSIONS dict does not include aarch64-linux-gnu. The toolchain declaration hardcodes x86_64 platform constraints.

What is blocked?
--------------------------------------------------------------------------------

aarch64 users cannot register or use toolchains_cc at all. Bazel's toolchain resolution rejects the toolchain because exec_compatible_with requires x86_64.

Solution
================================================================================

- Add get_host() helper to constants.bzl that derives the host platform from the target triple (only native builds supported: host arch == target arch)
- Replace hardcoded "x86_64-linux" in all download .bzl files with get_host()
- Add aarch64-linux-gnu to SUPPORTED_VERSIONS in config.bzl
- Add RELEASE_TO_DATE and TARBALL_TO_SHA256 entries for all aarch64 components (gcc, binutils, glibc, linux_headers)
- Pass target through eager_declare_toolchain to declare_toolchain
- Make platform constraints dynamic via _TARGET_TO_CPU_CONSTRAINT map
- Fix inaccuracies in add-toolchain-configuration runbook

Rationale
================================================================================

Why derive host from target instead of detecting with rctx.os? --------------------------------------------------------------------------------

Only native builds are supported currently (no cross-compilation), so the host architecture always matches the target architecture. Deriving from the target is simpler, avoids a runtime dependency on rctx.os, and keeps the mapping explicit and testable.

Why update all download files even though only glibc-based aarch64 is added? --------------------------------------------------------------------------------

The hardcoded x86_64-linux prefix was wrong in all files. Parameterizing them now means adding future architectures or targets only requires adding entries to RELEASE_TO_DATE and TARBALL_TO_SHA256, not changing the download logic.

Test Plan
================================================================================

- [x] buildifier lint passes
- [x] All examples build with aarch64-linux-gnu target on aarch64 host
- [x] Output binaries verified as ELF 64-bit ARM aarch64