### PR TITLE
feat: add aarch64-linux-musl toolchain support to Bazel configuration

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/docs/runbooks/update-binary-release-metadata.md
+++ b/docs/runbooks/update-binary-release-metadata.md
@@ -28,8 +28,10 @@ Each component has its own file in [private/downloads/](../../private/downloads/
 |---------------|-------------------------------------------------------------------|
 | GCC           | [private/downloads/gcc.bzl](../../private/downloads/gcc.bzl)           |
 | glibc         | [private/downloads/glibc.bzl](../../private/downloads/glibc.bzl)       |
+| musl          | [private/downloads/musl.bzl](../../private/downloads/musl.bzl)         |
 | binutils      | [private/downloads/binutils.bzl](../../private/downloads/binutils.bzl) |
 | Linux headers | [private/downloads/linux_headers.bzl](../../private/downloads/linux_headers.bzl) |
+| LLVM          | [private/downloads/llvm.bzl](../../private/downloads/llvm.bzl)         |
 
 ### 2. Find the new artifacts in the GitHub release
 
@@ -147,5 +149,5 @@ Old dated tarballs in the `binaries` release **must be preserved**. Previous ver
 
 ## Related Files
 
-- [private/downloads/constants.bzl](../../private/downloads/constants.bzl): Base URL for the `binaries` release
+- [private/downloads/constants.bzl](../../private/downloads/constants.bzl): Base URL and `get_host` helper
 - [private/downloads/all.bzl](../../private/downloads/all.bzl): Orchestrates all downloads

--- a/examples/boost/MODULE.bazel.lock
+++ b/examples/boost/MODULE.bazel.lock
@@ -335,7 +335,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "t07dFfXroD/Px6unuqd0UIInaJh0Ed03/8uqe2zWhq0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/fmt/MODULE.bazel.lock
+++ b/examples/fmt/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "Ogym/dCmE+yG3VjrEigpE5oYAo3HhD1gn3BPgweOWyg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/googletest/MODULE.bazel.lock
+++ b/examples/googletest/MODULE.bazel.lock
@@ -280,7 +280,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "zF9BFQevLFjrq1Y9IIpx6f93/ZXqI7e2NkgYy5deUHs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/sqlite/MODULE.bazel.lock
+++ b/examples/sqlite/MODULE.bazel.lock
@@ -209,7 +209,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "hmLP2+eWOtQrYKPXKM2vUUap6waUis9xTl4GTYjHe5I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/zlib/MODULE.bazel.lock
+++ b/examples/zlib/MODULE.bazel.lock
@@ -206,7 +206,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "KLh+0S9/jJzkEYXFDdXEVdFfBDFttBOGRsxrdxZmJ1s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/zstd/MODULE.bazel.lock
+++ b/examples/zstd/MODULE.bazel.lock
@@ -208,7 +208,7 @@
     },
     "@@toolchains_cc+//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5cpfcC6FOHEc0/a8gXJSeTZ3Vuo27DZRX2ORz9/kHVU=",
+        "bzlTransitiveDigest": "d5LF4MXZL3W7n2QkjMeoJGFpBXeN7vo3ZE2vdJxhedA=",
         "usagesDigest": "NRFDpWlXnA3yL2SDjG9Iaxpylu88xhp3HdOgPna5/pA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -89,6 +89,7 @@ SUPPORTED_VERSIONS = {
         "x86_64-linux-gnu": True,
         "x86_64-linux-musl": True,
         "aarch64-linux-gnu": True,
+        "aarch64-linux-musl": True,
     },
     "libc_version": {
         "1.2.5": True,

--- a/private/downloads/binutils.bzl
+++ b/private/downloads/binutils.bzl
@@ -40,10 +40,12 @@ RELEASE_TO_DATE = {
     "x86_64-linux-x86_64-linux-gnu-binutils-2.45": "20260218",
     "x86_64-linux-x86_64-linux-musl-binutils-2.45": "20260219",
     "aarch64-linux-aarch64-linux-gnu-binutils-2.45": "20260228",
+    "aarch64-linux-aarch64-linux-musl-binutils-2.45": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
     "x86_64-linux-x86_64-linux-gnu-binutils-2.45-20260218.tar.xz": "c1f56ffbadc36fc5b74f969e27e6eeca770d62286135f5a1b9ce044cf09135c3",
     "x86_64-linux-x86_64-linux-musl-binutils-2.45-20260219.tar.xz": "b68e2adae65d6eb22fbeb161acca652cae6eb5413581bcfa953072e1bbf9d79b",
     "aarch64-linux-aarch64-linux-gnu-binutils-2.45-20260228.tar.xz": "a0ec2a34a8f084911c747543b0dd54c62759990b46ea022e67a9c2c8c5a48e61",
+    "aarch64-linux-aarch64-linux-musl-binutils-2.45-20260228.tar.xz": "7f08c92cded3470555cdd2cdc1a315b008589c9c4a33ebf905876e2729df97bb",
 }

--- a/private/downloads/gcc.bzl
+++ b/private/downloads/gcc.bzl
@@ -54,6 +54,7 @@ RELEASE_TO_DATE = {
     "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260222",
     "x86_64-linux-x86_64-linux-musl-gcc-15.2.0": "20260222",
     "aarch64-linux-aarch64-linux-gnu-gcc-15.2.0": "20260228",
+    "aarch64-linux-aarch64-linux-musl-gcc-15.2.0": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
@@ -63,4 +64,6 @@ TARBALL_TO_SHA256 = {
     "x86_64-linux-musl-gcc-lib-15.2.0-20260222.tar.xz": "90e1049836ff83ae44e6c7cb0cd14d83913ea5963516e9131ed46dfc1e44d3e9",
     "aarch64-linux-aarch64-linux-gnu-gcc-15.2.0-20260228.tar.xz": "56103e50a905906ea78b0a4e291b4c3fb92b2a182cc3b185b55229d3323b219a",
     "aarch64-linux-gnu-gcc-lib-15.2.0-20260228.tar.xz": "93951d47eb9aa4d31e0167ab015d98b688d919659577573fae636ddb3c806559",
+    "aarch64-linux-aarch64-linux-musl-gcc-15.2.0-20260228.tar.xz": "8954b1a7a08a088fa692cf8b44e2522b33f45011e5712bb0123871a85c6cd4f7",
+    "aarch64-linux-musl-gcc-lib-15.2.0-20260228.tar.xz": "194dfbc9737df0262ab216c65ebb528d0686fe7a0f463a59e3e370f0598d923b",
 }

--- a/private/downloads/musl.bzl
+++ b/private/downloads/musl.bzl
@@ -34,8 +34,10 @@ def download_musl(rctx, config):
 
 RELEASE_TO_DATE = {
     "x86_64-linux-musl-musl-1.2.5": "20260220",
+    "aarch64-linux-musl-musl-1.2.5": "20260228",
 }
 
 TARBALL_TO_SHA256 = {
     "x86_64-linux-musl-musl-1.2.5-20260220.tar.xz": "bfaf13affe289e9ba795c268dd34ecefe6b06817b3681adfc7429e4ad7d07334",
+    "aarch64-linux-musl-musl-1.2.5-20260228.tar.xz": "db2fd8a16b19e7dd3a0d701ec7f400ad7f024750ad2809d3fbfce985d27b153c",
 }


### PR DESCRIPTION
Problem
================================================================================

Users on aarch64 machines cannot build statically linked musl-based binaries with toolchains_cc.

Context
================================================================================

The aarch64-linux-gnu (glibc) toolchain was added in the previous commit, but the musl-based toolchain was not yet configured. All aarch64 musl build artifacts (GCC, binutils, musl sysroot) have been built and published to the binaries GitHub release.

What functionality is missing?
--------------------------------------------------------------------------------

aarch64-linux-musl is not in SUPPORTED_VERSIONS and has no RELEASE_TO_DATE or TARBALL_TO_SHA256 entries, so Bazel cannot download the musl toolchain on aarch64.

Solution
================================================================================

- Add aarch64-linux-musl to SUPPORTED_VERSIONS in config.bzl
- Add RELEASE_TO_DATE and TARBALL_TO_SHA256 entries for aarch64 musl components (gcc, binutils, musl sysroot) — linux headers are already added
- Add missing musl and LLVM entries to update-binary-release-metadata runbook component table
- Add musl static linking note to add-toolchain-configuration runbook

Rationale
================================================================================

Why a separate commit from the glibc toolchain?
--------------------------------------------------------------------------------

The glibc and musl toolchains are independent configurations with separate build artifacts. Splitting them makes the change history clearer and each commit independently revertible.

Test Plan
================================================================================

- [x] buildifier lint passes
- [x] All examples build with aarch64-linux-musl target (static linking)
- [x] Output binaries verified as statically linked aarch64 ELF