### PR TITLE
feat: add GCC 13.4.0 toolchain support for x86_64-linux-gnu and x86_64-linux-musl

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "GWGKIlZj48aW0yxmiMWHhfAK61ig607+q0lRbX6I0o8=",
+        "bzlTransitiveDigest": "Toxd7ZeJqktY5RKlvXoCpKB1SHKr2UkqX3tLHmOW1Co=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -100,6 +100,7 @@ SUPPORTED_VERSIONS = {
         "llvm": True,
     },
     "compiler_version": {
+        "13.4.0": True,
         "14.2.0": True,
         "15.2.0": True,
         "21.1.1": True,

--- a/private/downloads/gcc.bzl
+++ b/private/downloads/gcc.bzl
@@ -51,6 +51,8 @@ def download_gcc(rctx, config):
     )
 
 RELEASE_TO_DATE = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-13.4.0": "20260306",
+    "x86_64-linux-x86_64-linux-musl-gcc-13.4.0": "20260306",
     "x86_64-linux-x86_64-linux-gnu-gcc-14.2.0": "20260305",
     "x86_64-linux-x86_64-linux-musl-gcc-14.2.0": "20260305",
     "x86_64-linux-x86_64-linux-gnu-gcc-15.2.0": "20260222",
@@ -60,6 +62,10 @@ RELEASE_TO_DATE = {
 }
 
 TARBALL_TO_SHA256 = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-13.4.0-20260306.tar.xz": "759e83721f05f7d6901f486d76de08750230dafc2eaf5de13d1c551b5d12aa14",
+    "x86_64-linux-gnu-gcc-lib-13.4.0-20260306.tar.xz": "54dcd554f6ed59f5a23a6e9f80d68b2e266f947ce0ef8e7c99b631fdc39c890a",
+    "x86_64-linux-x86_64-linux-musl-gcc-13.4.0-20260306.tar.xz": "438cb07d8b9f844b5702a904a07db7e6f8681fca1b418200fd45947a7be701e5",
+    "x86_64-linux-musl-gcc-lib-13.4.0-20260306.tar.xz": "9075bb17195924a3cdd5820b261ed20c30442b7afa9c22aabe129627c24b49af",
     "x86_64-linux-x86_64-linux-gnu-gcc-14.2.0-20260305.tar.xz": "050141f79deba9f627804195915b4ecf46fcb534f3a172cc7346f50d6e796d2d",
     "x86_64-linux-gnu-gcc-lib-14.2.0-20260305.tar.xz": "c6c92472db1c3578bf5c86b78115abbc9e745bd0e7f7d211bf0c158e3f99c29e",
     "x86_64-linux-x86_64-linux-musl-gcc-14.2.0-20260305.tar.xz": "0c7e9319e1088d5ac871e01aff6d255a98b7b3e06ad61cd8b533910af1f10fc2",


### PR DESCRIPTION
## Summary

- Adds GCC 13.4.0 as a supported compiler version for x86_64-linux-gnu (glibc) and x86_64-linux-musl targets
- Part of broader effort to support all recent GCC major versions (13, 14, 15)
- GCC 13.4.0 is the latest patch release of the GCC 13 series

## Test plan

- [x] `bazel test //tests/...` passes with x86_64-linux-gnu + glibc 2.28
- [x] `bazel build //tests/...` succeeds with x86_64-linux-musl + musl 1.2.5
- [x] All 14 examples build with x86_64-linux-gnu
- [x] 11/14 examples build with x86_64-linux-musl (3 known pre-existing musl failures: grpc, protobuf, rust_bindgen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)