### PR TITLE
fix: remove redundant -I${BUILD_TOOLS}/include from GCC build flags

### DIFF
--- a/.github/workflows/build_gcc/step-4.5_build_gcc
+++ b/.github/workflows/build_gcc/step-4.5_build_gcc
@@ -110,10 +110,10 @@ else
 fi
 
 env CC_FOR_BUILD=gcc \
-    CFLAGS="-O2 -I${BUILD_TOOLS}/include" \
-    CFLAGS_FOR_BUILD="-O2 -I${BUILD_TOOLS}/include" \
-    CXXFLAGS="-O2 -I${BUILD_TOOLS}/include" \
-    CXXFLAGS_FOR_BUILD="-O2 -I${BUILD_TOOLS}/include" \
+    CFLAGS="-O2" \
+    CFLAGS_FOR_BUILD="-O2" \
+    CXXFLAGS="-O2" \
+    CXXFLAGS_FOR_BUILD="-O2" \
     LDFLAGS="-L${BUILD_TOOLS}/lib -static" \
     CFLAGS_FOR_TARGET="-O2" \
     CXXFLAGS_FOR_TARGET="-O2" \


### PR DESCRIPTION
## Summary

- Remove `-I${BUILD_TOOLS}/include` from `CFLAGS`, `CFLAGS_FOR_BUILD`, `CXXFLAGS`, and `CXXFLAGS_FOR_BUILD` in the final GCC build step
- Fixes GCC 12.5.0 build failure caused by the bootstrap-installed `ansidecl.h` (which no longer defines `PTR`) shadowing the source tree's version
- The include path was inherited from crosstool-ng and was never needed — `--with-gmp/mpfr/mpc/isl` configure flags already handle dependency header resolution

## Test plan

- [x] GCC 12.5.0 x86_64-linux-gnu builds successfully
- [x] Swept several other GCC version and target combinations with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)