### PR TITLE
feat: add GCC 11.5.0 toolchain support for x86_64-linux-gnu and x86_64-linux-musl

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "qdfoDozItKJyAeTNJo5Ju3J7oXtorVYa7fxavvlKg3c=",
+        "bzlTransitiveDigest": "QhUmS9kPFUhSM+eATyJcxj6dvplHU5jiDYnQ8DL84zo=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -100,6 +100,7 @@ SUPPORTED_VERSIONS = {
         "llvm": True,
     },
     "compiler_version": {
+        "11.5.0": True,
         "12.5.0": True,
         "13.4.0": True,
         "14.2.0": True,

--- a/private/downloads/gcc.bzl
+++ b/private/downloads/gcc.bzl
@@ -51,6 +51,8 @@ def download_gcc(rctx, config):
     )
 
 RELEASE_TO_DATE = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-11.5.0": "20260310",
+    "x86_64-linux-x86_64-linux-musl-gcc-11.5.0": "20260310",
     "x86_64-linux-x86_64-linux-gnu-gcc-12.5.0": "20260310",
     "x86_64-linux-x86_64-linux-musl-gcc-12.5.0": "20260306",
     "x86_64-linux-x86_64-linux-gnu-gcc-13.4.0": "20260306",
@@ -64,6 +66,10 @@ RELEASE_TO_DATE = {
 }
 
 TARBALL_TO_SHA256 = {
+    "x86_64-linux-x86_64-linux-gnu-gcc-11.5.0-20260310.tar.xz": "d8c3e210c27191cfd2b385ebd67dabb0b4f7b1c3d5ee4340d2fe121161112dba",
+    "x86_64-linux-gnu-gcc-lib-11.5.0-20260310.tar.xz": "4662995938bf7b39d0ca1486b9dad9b236345ccf915ba4fcd5e4bb16d0a33582",
+    "x86_64-linux-x86_64-linux-musl-gcc-11.5.0-20260310.tar.xz": "a2379ae82c7fca5ad2e308e2fe5e783f5d3cbfdb73e7aea43d21bb3939c391bc",
+    "x86_64-linux-musl-gcc-lib-11.5.0-20260310.tar.xz": "e470e7383171084c0295db8ddd4b7ff3267c81c43f0d2a3ac256ac1421511d22",
     "x86_64-linux-x86_64-linux-gnu-gcc-12.5.0-20260310.tar.xz": "426c3d28aa5d1701f0a667545c09a8a1dbcef9a76f7294cfd9a42feeea8d6f19",
     "x86_64-linux-gnu-gcc-lib-12.5.0-20260310.tar.xz": "f5f8a2ba506ad3e8c11501b43e7efe09fd03511a5c47ddc9a34711b56e7f0edb",
     "x86_64-linux-x86_64-linux-musl-gcc-12.5.0-20260306.tar.xz": "5513705c97351b9ea32bf1fe3057c24717a2e45b055d3dff78600be027de92c9",


### PR DESCRIPTION
## Summary

- Add GCC 11.5.0 (latest patch in GCC 11 series) as a supported compiler version for x86_64-linux-gnu and x86_64-linux-musl targets
- Built and published source, bootstrap, and full GCC 11.5.0 binaries to the `binaries` release
- Added `SUPPORTED_VERSIONS`, `RELEASE_TO_DATE`, and `TARBALL_TO_SHA256` entries

Part of expanding GCC version coverage across all actively maintained release series. aarch64 support will follow in a separate PR.

## Test plan

- [x] `bazel test //tests/...` passes with x86_64-linux-gnu + glibc 2.28
- [x] `bazel build //tests/...` passes with x86_64-linux-musl + musl 1.2.5
- [x] All 14 examples build with x86_64-linux-gnu
- [x] All examples build with x86_64-linux-musl (grpc, protobuf, rust_bindgen have pre-existing musl failures)
- [x] `buildifier.check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)