### PR TITLE
feat: add glibc 2.30 toolchain support

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "MLb+iDYRaYN4MERAQarVL4U2qpmJOg/I1LeiomMYOl0=",
+        "bzlTransitiveDigest": "scKJAAF/tKQfbAhkuD0Be7jRCamACr0bq1FQZugtyVE=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -108,6 +108,7 @@ SUPPORTED_VERSIONS = {
         "1.2.5": True,
         "2.28": True,
         "2.29": True,
+        "2.30": True,
     },
     "compiler": {
         "gcc": True,

--- a/private/downloads/glibc.bzl
+++ b/private/downloads/glibc.bzl
@@ -37,6 +37,8 @@ RELEASE_TO_DATE = {
     "aarch64-linux-gnu-glibc-2.28": "20260228",
     "x86_64-linux-gnu-glibc-2.29": "20260311",
     "aarch64-linux-gnu-glibc-2.29": "20260311",
+    "x86_64-linux-gnu-glibc-2.30": "20260311",
+    "aarch64-linux-gnu-glibc-2.30": "20260311",
 }
 
 TARBALL_TO_SHA256 = {
@@ -44,4 +46,6 @@ TARBALL_TO_SHA256 = {
     "aarch64-linux-gnu-glibc-2.28-20260228.tar.xz": "28a46420f38d2f975544f24ee70cedd45c698abed32e567eaa60db0eeb4364b0",
     "x86_64-linux-gnu-glibc-2.29-20260311.tar.xz": "04b3e173d1f1f9bd7cc18ebe65f37bcda934b4c8f85ee24f7cf8de1f7ef96ab4",
     "aarch64-linux-gnu-glibc-2.29-20260311.tar.xz": "af89007391be9ad68be00445d2b0de50d0e0ab422435cc27800307b3ce26787d",
+    "x86_64-linux-gnu-glibc-2.30-20260311.tar.xz": "66fa79ae6974f1c9b8048501830473c55ebf05ae8510a671aee232351a496ce1",
+    "aarch64-linux-gnu-glibc-2.30-20260311.tar.xz": "2d4d2f27559dec5f95415e3dd7bb5e4ee3ddb36516f1b969214cadd66a365cf4",
 }


### PR DESCRIPTION
## Summary
- Add glibc 2.30 sysroot support for x86_64 and aarch64 targets
- Update `SUPPORTED_VERSIONS` in `private/config.bzl`
- Add release metadata and SHA256 hashes in `private/downloads/glibc.bzl`

## Test plan
- [x] glibc 2.30 sysroot binaries built for x86_64 and aarch64
- [x] `bazel test //tests/...` passes with glibc 2.30
- [x] All 14 examples build successfully with glibc 2.30
- [x] buildifier lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)