### PR TITLE
feat: add Linux kernel headers 6.16 support

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "ZssAhEdKvwhS1UmaBGSajuG0XPv2BNlVKISTa7Uzz7A=",
+        "bzlTransitiveDigest": "5Iccf7JGf7sQspIWM65fhj4cb3GPIEVUevNygV8j+zw=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/docs/runbooks/add-new-linux-headers-version.md
+++ b/docs/runbooks/add-new-linux-headers-version.md
@@ -156,6 +156,7 @@ Linux kernel headers are backward compatible -- userspace code compiled against 
 
 | Version | Release date | Notable additions |
 |---|---|---|
+| 6.16 | 2025-01 | — |
 | 6.17 | 2025-03 | — |
 | 6.18 | 2025-05 | — |
 

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -135,6 +135,7 @@ SUPPORTED_VERSIONS = {
         "2.45": True,
     },
     "linux_headers_version": {
+        "6.16": True,
         "6.17": True,
         "6.18": True,
     },

--- a/private/downloads/linux_headers.bzl
+++ b/private/downloads/linux_headers.bzl
@@ -36,6 +36,8 @@ def download_linux_headers(rctx, config):
     )
 
 RELEASE_TO_DATE = {
+    "x86_64-linux-headers-6.16": "20260312",
+    "aarch64-linux-headers-6.16": "20260312",
     "x86_64-linux-headers-6.17": "20260312",
     "aarch64-linux-headers-6.17": "20260312",
     "x86_64-linux-headers-6.18": "20260217",
@@ -43,6 +45,8 @@ RELEASE_TO_DATE = {
 }
 
 TARBALL_TO_SHA256 = {
+    "x86_64-linux-headers-6.16-20260312.tar.xz": "8dab681fa4f3c2142725b44cd8c97abec6ff7a55b54c56b3af689c9d312f7728",
+    "aarch64-linux-headers-6.16-20260312.tar.xz": "592f2589d6da8b284d824cfd00942488b83474acd2b3726e1d1b32204a16dd8e",
     "x86_64-linux-headers-6.17-20260312.tar.xz": "16ef4f46ca00c7fc901c82a3194a5858ced8ff12596125991724d9d971878553",
     "aarch64-linux-headers-6.17-20260312.tar.xz": "862a20b02812c11cccbb133566ab8ea260614f8ea5f14bb6f7203c5189704ae9",
     "x86_64-linux-headers-6.18-20260217.tar.xz": "34396267a578ef4b81b3951b826c236cf385f7f008bb20b348731ca3318b7c6f",


### PR DESCRIPTION
## Summary
- Add Linux kernel headers 6.16 support for x86_64 and aarch64
- Built and uploaded source tarball and header binaries via GitHub Actions
- Added version to `SUPPORTED_VERSIONS`, `RELEASE_TO_DATE`, and `TARBALL_TO_SHA256`
- Added 6.16 to the version compatibility table in the linux headers runbook

## Test plan
- [x] `bazel test //tests/...` passes with `linux_headers_version=6.16`
- [x] All 14 examples build successfully with `linux_headers_version=6.16`
- [x] `buildifier.check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)