### PR TITLE
feat: add Linux kernel headers 6.10-6.15 support

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5Iccf7JGf7sQspIWM65fhj4cb3GPIEVUevNygV8j+zw=",
+        "bzlTransitiveDigest": "Af1vv1EsAstgwNzvM5cEzpDny3x5RiVTsvPA7jKcvtM=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/docs/runbooks/add-new-linux-headers-version.md
+++ b/docs/runbooks/add-new-linux-headers-version.md
@@ -156,9 +156,15 @@ Linux kernel headers are backward compatible -- userspace code compiled against 
 
 | Version | Release date | Notable additions |
 |---|---|---|
-| 6.16 | 2025-01 | — |
-| 6.17 | 2025-03 | — |
-| 6.18 | 2025-05 | — |
+| 6.10 | 2024-07 | — |
+| 6.11 | 2024-09 | — |
+| 6.12 | 2024-11 | — |
+| 6.13 | 2025-01 | — |
+| 6.14 | 2025-03 | — |
+| 6.15 | 2025-05 | — |
+| 6.16 | 2025-07 | — |
+| 6.17 | 2025-09 | — |
+| 6.18 | 2025-11 | — |
 
 ## Checklist
 

--- a/private/config.bzl
+++ b/private/config.bzl
@@ -135,6 +135,12 @@ SUPPORTED_VERSIONS = {
         "2.45": True,
     },
     "linux_headers_version": {
+        "6.10": True,
+        "6.11": True,
+        "6.12": True,
+        "6.13": True,
+        "6.14": True,
+        "6.15": True,
         "6.16": True,
         "6.17": True,
         "6.18": True,

--- a/private/downloads/linux_headers.bzl
+++ b/private/downloads/linux_headers.bzl
@@ -36,6 +36,18 @@ def download_linux_headers(rctx, config):
     )
 
 RELEASE_TO_DATE = {
+    "x86_64-linux-headers-6.10": "20260312",
+    "aarch64-linux-headers-6.10": "20260312",
+    "x86_64-linux-headers-6.11": "20260312",
+    "aarch64-linux-headers-6.11": "20260312",
+    "x86_64-linux-headers-6.12": "20260312",
+    "aarch64-linux-headers-6.12": "20260312",
+    "x86_64-linux-headers-6.13": "20260312",
+    "aarch64-linux-headers-6.13": "20260312",
+    "x86_64-linux-headers-6.14": "20260312",
+    "aarch64-linux-headers-6.14": "20260312",
+    "x86_64-linux-headers-6.15": "20260312",
+    "aarch64-linux-headers-6.15": "20260312",
     "x86_64-linux-headers-6.16": "20260312",
     "aarch64-linux-headers-6.16": "20260312",
     "x86_64-linux-headers-6.17": "20260312",
@@ -45,6 +57,18 @@ RELEASE_TO_DATE = {
 }
 
 TARBALL_TO_SHA256 = {
+    "x86_64-linux-headers-6.10-20260312.tar.xz": "c923cb5f00209cbfb6f8481d2e26afb542126bafb15605e031fdac16c5d4a5bf",
+    "aarch64-linux-headers-6.10-20260312.tar.xz": "14dc7cf3af1b19f3f931ccd77190af18bebec97814e610ad058913834c2bf7d9",
+    "x86_64-linux-headers-6.11-20260312.tar.xz": "4d26e75348d5bcbbd6da43a296506e6565fd892c6ef8c026cb51c1165f1d079a",
+    "aarch64-linux-headers-6.11-20260312.tar.xz": "f54f7adb080a701729943a944aa4ab92f013aef8475d01bbe29222ae5efd06d7",
+    "x86_64-linux-headers-6.12-20260312.tar.xz": "631caface55d477d0ddf7a9153506174313f121de0694f1806709c911bb46055",
+    "aarch64-linux-headers-6.12-20260312.tar.xz": "ef5a7c2c6ad1f9d37eb8df9f0be066889bfcd8b58f87da0ee0e9e14338d365e9",
+    "x86_64-linux-headers-6.13-20260312.tar.xz": "5e75a9430821f89a47eb6d538f378693f17ca1c20e4a18d25faeb4ff9ca0996c",
+    "aarch64-linux-headers-6.13-20260312.tar.xz": "1f71cdcd24cb06a81a9055478ea677f8ce9a93f372eee415339639aac6e04f33",
+    "x86_64-linux-headers-6.14-20260312.tar.xz": "f4b9d5c2234a542adc165c480888780d7fddbf95112a2054bb18696d11cea132",
+    "aarch64-linux-headers-6.14-20260312.tar.xz": "36cd863a3f2b4fbbe538e2b7d9622bc0c5538f58603f591ed2aad3b628e8eddb",
+    "x86_64-linux-headers-6.15-20260312.tar.xz": "4cb578eb4c63004233ef29a73911730ff5160d5bcd9deeb737a457f1670141a3",
+    "aarch64-linux-headers-6.15-20260312.tar.xz": "3f01d9c43b37ebba3f7d2ea7330b01e980a6002641fcc4e4ea12932ac2244ad5",
     "x86_64-linux-headers-6.16-20260312.tar.xz": "8dab681fa4f3c2142725b44cd8c97abec6ff7a55b54c56b3af689c9d312f7728",
     "aarch64-linux-headers-6.16-20260312.tar.xz": "592f2589d6da8b284d824cfd00942488b83474acd2b3726e1d1b32204a16dd8e",
     "x86_64-linux-headers-6.17-20260312.tar.xz": "16ef4f46ca00c7fc901c82a3194a5858ced8ff12596125991724d9d971878553",


### PR DESCRIPTION
## Summary
- Add Linux kernel headers 6.10, 6.11, 6.12, 6.13, 6.14, and 6.15 for x86_64 and aarch64
- Built and uploaded source tarballs and header binaries via GitHub Actions
- Added all 6 versions to `SUPPORTED_VERSIONS`, `RELEASE_TO_DATE`, and `TARBALL_TO_SHA256`
- Updated version compatibility table in the linux headers runbook (added 6.10-6.15, corrected release dates for existing entries)

## Test plan
- [x] `bazel test //tests/...` passes for each version 6.10 through 6.15
- [x] All 14 examples build successfully for each version
- [x] `buildifier.check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)