### PR TITLE
feat: add aarch64 support to LLVM/Clang build workflow

### DIFF
--- a/.github/workflows/build_libclang/step-5_package_toolchain
+++ b/.github/workflows/build_libclang/step-5_package_toolchain
@@ -5,7 +5,6 @@ source ${SCRIPTS_DIR}/environment
 pushd ${ARTIFACTS_DIR}
 
 RELEASE_NAME="x86_64-linux-libclang-${LLVM_VERSION}-$(date +%Y%m%d)"
-echo $RELEASE_NAME > ${ARTIFACTS_DIR}/release_name
 
 XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${RELEASE_NAME}.tar.xz" \
     lib/libclang* \

--- a/.github/workflows/build_llvm/environment
+++ b/.github/workflows/build_llvm/environment
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euox pipefail
 
+export BUILD_ARCH=$(uname -m)
+
 # ==============================
 # || Setup Source Directories ||
 # ==============================

--- a/.github/workflows/build_llvm/step-2.3_install_gcc
+++ b/.github/workflows/build_llvm/step-2.3_install_gcc
@@ -5,7 +5,7 @@ source ${SCRIPTS_DIR}/environment
 # Needs to be musl based to statically link LLVM.
 # When attempting glibc, it failed to link because clang uses some symbols
 # that are only available when dynamic linking glibc.
-"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-musl-gcc-${GCC_VERSION}-" "${GCC_DIR}"
-"${UTILS_DIR}/download_tarball" "x86_64-linux-musl-gcc-lib-${GCC_VERSION}-" "${GCC_DIR}"
-"${UTILS_DIR}/download_tarball" "x86_64-linux-x86_64-linux-musl-binutils-2.45-" "${GCC_DIR}"
-"${UTILS_DIR}/download_tarball" "x86_64-linux-musl-musl-1.2.5-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-linux-musl-gcc-${GCC_VERSION}-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-musl-gcc-lib-${GCC_VERSION}-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-${BUILD_ARCH}-linux-musl-binutils-2.45-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-musl-musl-1.2.5-" "${GCC_DIR}"

--- a/.github/workflows/build_llvm/step-2.4_install_linux_headers
+++ b/.github/workflows/build_llvm/step-2.4_install_linux_headers
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euox pipefail
 source ${SCRIPTS_DIR}/environment
-"${UTILS_DIR}/download_tarball" "x86_64-linux-headers-${LINUX_VERSION}-" "${GCC_DIR}"
+"${UTILS_DIR}/download_tarball" "${BUILD_ARCH}-linux-headers-${LINUX_VERSION}-" "${GCC_DIR}"

--- a/.github/workflows/build_llvm/step-3_build_zlib
+++ b/.github/workflows/build_llvm/step-3_build_zlib
@@ -7,8 +7,8 @@ pushd ${ZLIB_DIR}
 cp -r ${ZLIB_SOURCE}/* .
 
 export PATH=${GCC_BINS}:$PATH
-export CC="${GCC_BINS}/x86_64-linux-musl-gcc"
-export CXX="${GCC_BINS}/x86_64-linux-musl-g++"
+export CC="${GCC_BINS}/${BUILD_ARCH}-linux-musl-gcc"
+export CXX="${GCC_BINS}/${BUILD_ARCH}-linux-musl-g++"
 export CFLAGS="-fPIC --sysroot=${GCC_SYSROOT}"
 export CXXFLAGS="--sysroot=${GCC_SYSROOT}"
 

--- a/.github/workflows/build_llvm/step-4_build_llvm
+++ b/.github/workflows/build_llvm/step-4_build_llvm
@@ -15,8 +15,8 @@ cmake -G Ninja -S llvm -B build \
     -DLLVM_LINK_LLVM_DYLIB=OFF \
     -DBUILD_SHARED_LIBS=OFF \
     -DLLVM_ENABLE_ZLIB=ON \
-    -DCMAKE_C_COMPILER="${GCC_BINS}/x86_64-linux-musl-gcc" \
-    -DCMAKE_CXX_COMPILER="${GCC_BINS}/x86_64-linux-musl-g++" \
+    -DCMAKE_C_COMPILER="${GCC_BINS}/${BUILD_ARCH}-linux-musl-gcc" \
+    -DCMAKE_CXX_COMPILER="${GCC_BINS}/${BUILD_ARCH}-linux-musl-g++" \
     -DCMAKE_SYSROOT="${GCC_SYSROOT}" \
     -DCMAKE_EXE_LINKER_FLAGS="-static -s" \
     -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/build_llvm/step-5_package_toolchain
+++ b/.github/workflows/build_llvm/step-5_package_toolchain
@@ -4,8 +4,7 @@ source ${SCRIPTS_DIR}/environment
 
 pushd ${ARTIFACTS_DIR}
 
-RELEASE_NAME="x86_64-linux-llvm-${LLVM_VERSION}-$(date +%Y%m%d)"
-echo $RELEASE_NAME > ${ARTIFACTS_DIR}/release_name
+RELEASE_NAME="${BUILD_ARCH}-linux-llvm-${LLVM_VERSION}-$(date +%Y%m%d)"
 
 XZ_OPT=-e9 tar cJf "${ARTIFACTS_DIR}/${RELEASE_NAME}.tar.xz" \
     bin/clang \

--- a/.github/workflows/build_llvm_aarch64.yml
+++ b/.github/workflows/build_llvm_aarch64.yml
@@ -1,4 +1,4 @@
-name: Build LLVM/Clang
+name: Build LLVM/Clang (aarch64)
 
 on:
   workflow_dispatch:
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_llvm_x86_64.yml
+++ b/.github/workflows/build_llvm_x86_64.yml
@@ -1,0 +1,89 @@
+name: Build LLVM/Clang (x86_64)
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvm_version:
+        description: 'LLVM version to build'
+        required: true
+        default: '21.1.1'
+        type: string
+      zlib_version:
+        description: 'zlib version to build'
+        required: true
+        default: '1.3.1'
+        type: string
+      gcc_version:
+        description: 'GCC version to use for compilation'
+        required: true
+        default: '15.2.0'
+        type: string
+
+permissions:
+  # Required for uploading GitHub releases
+  contents: write
+  # Required for build provenance attestation
+  id-token: write
+  attestations: write
+
+env:
+  SCRIPTS_DIR: ${{ github.workspace }}/.github/workflows/build_llvm
+  UTILS_DIR: ${{ github.workspace }}/.github/workflows/utils
+  ZLIB_VERSION: ${{ github.event.inputs.zlib_version }}
+  LLVM_VERSION: ${{ github.event.inputs.llvm_version }}
+  GCC_VERSION: ${{ github.event.inputs.gcc_version }}
+  LINUX_VERSION: '6.18'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install dependencies
+        run: $SCRIPTS_DIR/step-1_install_dependencies
+
+      - name: Set up environment
+        run: $SCRIPTS_DIR/environment
+
+      - name: Download zlib source
+        run: $SCRIPTS_DIR/step-2.1_download_zlib_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download LLVM source
+        run: $SCRIPTS_DIR/step-2.2_download_llvm_source
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install GCC toolchain
+        run: $SCRIPTS_DIR/step-2.3_install_gcc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install Linux headers
+        run: $SCRIPTS_DIR/step-2.4_install_linux_headers
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build zlib
+        run: $SCRIPTS_DIR/step-3_build_zlib
+
+      - name: Build LLVM
+        run: $SCRIPTS_DIR/step-4_build_llvm
+
+      - name: Package toolchain
+        run: $SCRIPTS_DIR/step-5_package_toolchain
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: |
+            ${{ env.ARTIFACTS_DIR }}/*.tar.xz
+
+      - name: Upload to GitHub Releases
+        run: $SCRIPTS_DIR/step-6_upload_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -193,7 +193,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%cc_toolchains": {
       "general": {
-        "bzlTransitiveDigest": "5fUALOwaeygPUmT3HacW6Rr7YiHyn2I5skL8kHpKum4=",
+        "bzlTransitiveDigest": "y/90Op5CkDJ5bGSWRLxi6khFj+FppFzQ9bdTuFpkWrI=",
         "usagesDigest": "F6SX7iKS1faQQN696xRADv8Sz7EQwIN/QCkd3xTcCBo=",
         "recordedInputs": [],
         "generatedRepoSpecs": {


### PR DESCRIPTION
## Summary
- Split `build_llvm.yml` into `build_llvm_x86_64.yml` and `build_llvm_aarch64.yml` to match the pattern used by all other build workflows
- Parameterize LLVM build scripts to use `BUILD_ARCH=$(uname -m)` instead of hardcoded `x86_64`, so both workflows share the same script directory
- Minor cleanup: remove unused `release_name` file writes from LLVM and libclang packaging scripts

## Test plan
- [ ] Dispatch `Build LLVM/Clang (x86_64)` workflow and verify it completes successfully
- [ ] Dispatch `Build LLVM/Clang (aarch64)` workflow and verify it completes successfully
- [ ] Verify release artifacts are named correctly (`x86_64-linux-llvm-*` and `aarch64-linux-llvm-*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)